### PR TITLE
Add a `stress_test` example to investigate performance

### DIFF
--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -4,6 +4,11 @@
 //! This example uses command line flags to determine which type of billboards to render.
 //! Run this example as `cargo run --example stress_test text` to render text billboards,
 //! or `cargo run --example stress_test texture` to render image-based billboards.
+//!
+//! To test the performance of constantly recomputing billboards,
+//! add the `recompute` argument to your invocation above.
+//! For example `cargo run --example stress_test text recompute` will render text billboards
+//! and recompute them every frame.
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -18,6 +23,7 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
+        .add_system(recompute_billboards)
         .run();
 }
 
@@ -73,5 +79,25 @@ fn setup(
                 }
             }
         }
+    }
+}
+
+fn recompute_billboards(
+    mut text_query: Query<&mut Text>,
+    mut billboard_query: Query<&mut Handle<BillboardTexture>>,
+) {
+    // Only do this work if we're testing performance of recomputing billboards
+    if !std::env::args().any(|arg| arg == "recompute") {
+        return;
+    };
+
+    for mut text in text_query.iter_mut() {
+        // Simply setting changed on the text component will cause the billboard to be recomputed
+        text.set_changed();
+    }
+
+    for mut billboard_texture_handle in billboard_query.iter_mut() {
+        // Simply setting changed on the mesh component will cause the billboard to be recomputed
+        billboard_texture_handle.set_changed();
     }
 }

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -1,0 +1,49 @@
+//! Tests the performance of the library
+//! by rendering a large number of billboarded objects at once.
+
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::{shape::Quad, *},
+};
+use bevy_mod_billboard::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(BillboardPlugin)
+        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut billboard_textures: ResMut<Assets<BillboardTexture>>,
+    mut meshes: ResMut<Assets<Mesh>>,
+) {
+    let image_handle: Handle<Image> = asset_server.load("rust-logo-256x256.png");
+    let billboard_texture_handle = billboard_textures.add(BillboardTexture::Single(image_handle));
+    let mesh_handle = meshes.add(Quad::new(Vec2::new(1., 1.)).into());
+    let billboard_mesh_handle = BillboardMeshHandle(mesh_handle);
+
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_translation(Vec3::new(0., 0., 100.))
+            .looking_at(Vec3::ZERO, Vec3::Y),
+        ..Default::default()
+    });
+
+    for x in -10..=10 {
+        for y in -10..=10 {
+            for z in -10..=10 {
+                commands.spawn(BillboardTextureBundle {
+                    texture: billboard_texture_handle.clone(),
+                    mesh: billboard_mesh_handle.clone(),
+                    transform: Transform::from_translation(Vec3::new(x as f32, y as f32, z as f32)),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+}

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -1,5 +1,9 @@
 //! Tests the performance of the library
 //! by rendering a large number of billboarded objects at once.
+//!
+//! This example uses command line flags to determine which type of billboards to render.
+//! Run this example as `cargo run --example stress_test text` to render text billboards,
+//! or `cargo run --example stress_test texture` to render image-based billboards.
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
@@ -27,6 +31,7 @@ fn setup(
     let billboard_texture_handle = billboard_textures.add(BillboardTexture::Single(image_handle));
     let mesh_handle = meshes.add(Quad::new(Vec2::new(1., 1.)).into());
     let billboard_mesh_handle = BillboardMeshHandle(mesh_handle);
+    let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
 
     commands.spawn(Camera3dBundle {
         transform: Transform::from_translation(Vec3::new(0., 0., 50.))
@@ -37,12 +42,35 @@ fn setup(
     for x in -10..=10 {
         for y in -10..=10 {
             for z in -10..=10 {
-                commands.spawn(BillboardTextureBundle {
-                    texture: billboard_texture_handle.clone(),
-                    mesh: billboard_mesh_handle.clone(),
-                    transform: Transform::from_translation(Vec3::new(x as f32, y as f32, z as f32)),
-                    ..Default::default()
-                });
+                let translation = Vec3::new(x as f32, y as f32, z as f32);
+
+                if std::env::args().any(|arg| arg == "text") {
+                    commands.spawn(BillboardTextBundle {
+                        transform: Transform {
+                            translation,
+                            rotation: Quat::IDENTITY,
+                            scale: Vec3::splat(0.0085),
+                        },
+                        text: Text::from_section(
+                            "STRESS",
+                            TextStyle {
+                                font_size: 60.0,
+                                font: fira_sans_regular_handle.clone(),
+                                color: Color::ORANGE,
+                            },
+                        ),
+                        ..default()
+                    });
+                }
+
+                if std::env::args().any(|arg| arg == "texture") {
+                    commands.spawn(BillboardTextureBundle {
+                        texture: billboard_texture_handle.clone(),
+                        mesh: billboard_mesh_handle.clone(),
+                        transform: Transform::from_translation(translation),
+                        ..Default::default()
+                    });
+                }
             }
         }
     }

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -29,7 +29,7 @@ fn setup(
     let billboard_mesh_handle = BillboardMeshHandle(mesh_handle);
 
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(0., 0., 100.))
+        transform: Transform::from_translation(Vec3::new(0., 0., 50.))
             .looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -45,9 +45,9 @@ fn setup(
         ..Default::default()
     });
 
-    for x in -10..=10 {
-        for y in -10..=10 {
-            for z in -10..=10 {
+    for x in -5..=5 {
+        for y in -5..=5 {
+            for z in -5..=5 {
                 let translation = Vec3::new(x as f32, y as f32, z as f32);
 
                 if std::env::args().any(|arg| arg == "text") {

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -97,7 +97,7 @@ fn recompute_billboards(
     }
 
     for mut billboard_texture_handle in billboard_query.iter_mut() {
-        // Simply setting changed on the mesh component will cause the billboard to be recomputed
+        // Simply setting changed on the texture component will cause the billboard to be recomputed
         billboard_texture_handle.set_changed();
     }
 }

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -6,8 +6,10 @@
 //! or `cargo run --example stress_test texture` to render image-based billboards.
 //!
 //! To test the performance of constantly recomputing billboards,
-//! add the `recompute` argument to your invocation above.
-//! For example `cargo run --example stress_test text recompute` will render text billboards
+//! add the `recompute_text` or `recompute_texture` argument to your invocation above.
+//! `recompute_text` trigger change detection to Text while `recompute_texture` triggers
+//! change detection to BillboardTexture.
+//! For example `cargo run --example stress_test text recompute_text` will render text billboards
 //! and recompute them every frame.
 
 use bevy::{
@@ -19,24 +21,31 @@ use bevy_mod_billboard::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(BillboardPlugin)
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(recompute_billboards)
+        .add_plugins(BillboardPlugin)
+        .add_plugins((
+            FrameTimeDiagnosticsPlugin::default(),
+            LogDiagnosticsPlugin::default(),
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, recompute_billboards)
         .run();
+}
+
+#[derive(Resource)]
+struct Settings {
+    recompute_text: bool,
+    recompute_texture: bool,
 }
 
 fn setup(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut billboard_textures: ResMut<Assets<BillboardTexture>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image_handle: Handle<Image> = asset_server.load("rust-logo-256x256.png");
-    let billboard_texture_handle = billboard_textures.add(BillboardTexture::Single(image_handle));
+    let billboard_texture = BillboardTexture(image_handle);
     let mesh_handle = meshes.add(Quad::new(Vec2::new(1., 1.)).into());
-    let billboard_mesh_handle = BillboardMeshHandle(mesh_handle);
+    let billboard_mesh = BillboardMesh(mesh_handle);
     let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
 
     commands.spawn(Camera3dBundle {
@@ -45,9 +54,9 @@ fn setup(
         ..Default::default()
     });
 
-    for x in -5..=5 {
-        for y in -5..=5 {
-            for z in -5..=5 {
+    for x in -10..=10 {
+        for y in -10..=10 {
+            for z in -10..=10 {
                 let translation = Vec3::new(x as f32, y as f32, z as f32);
 
                 if std::env::args().any(|arg| arg == "text") {
@@ -71,8 +80,8 @@ fn setup(
 
                 if std::env::args().any(|arg| arg == "texture") {
                     commands.spawn(BillboardTextureBundle {
-                        texture: billboard_texture_handle.clone(),
-                        mesh: billboard_mesh_handle.clone(),
+                        texture: billboard_texture.clone(),
+                        mesh: billboard_mesh.clone(),
                         transform: Transform::from_translation(translation),
                         ..Default::default()
                     });
@@ -80,24 +89,30 @@ fn setup(
             }
         }
     }
+
+    commands.insert_resource(Settings {
+        recompute_texture: std::env::args().any(|arg| arg == "recompute_texture"),
+        recompute_text: std::env::args().any(|arg| arg == "recompute_text"),
+    });
 }
 
 fn recompute_billboards(
     mut text_query: Query<&mut Text>,
-    mut billboard_query: Query<&mut Handle<BillboardTexture>>,
+    mut billboard_query: Query<&mut BillboardTexture>,
+    settings: Res<Settings>,
 ) {
-    // Only do this work if we're testing performance of recomputing billboards
-    if !std::env::args().any(|arg| arg == "recompute") {
-        return;
-    };
-
-    for mut text in text_query.iter_mut() {
-        // Simply setting changed on the text component will cause the billboard to be recomputed
-        text.set_changed();
+    if settings.recompute_text {
+        for mut text in text_query.iter_mut() {
+            // Simply setting changed on the text component will cause the billboard to be recomputed
+            // This is expected as text is recalculated using change detection
+            text.set_changed();
+        }
     }
 
-    for mut billboard_texture_handle in billboard_query.iter_mut() {
-        // Simply setting changed on the texture component will cause the billboard to be recomputed
-        billboard_texture_handle.set_changed();
+    if settings.recompute_texture {
+        for mut billboard_texture in billboard_query.iter_mut() {
+            // This should be negligible
+            billboard_texture.set_changed();
+        }
     }
 }


### PR DESCRIPTION
Used for reproducing #8.

![image](https://user-images.githubusercontent.com/3579909/234344798-7712d173-1f04-4d99-b976-0ae07c3f0a7a.png)

My FPS across each of the settings:

| Mode    | Static | Recomputed |
|---------|--------|------------|
| Text    | 5      | 0.04       |
| Texture | 14     | 14         |

Note that I sometimes got crashes due to running out of memory on my GPU with `cargo run --example stress_test text recompute`.

