### PR TITLE
lock rotation / non-billboard mode (for 3d text entities)

### DIFF
--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy::prelude::shape::{Plane, Quad};
-use bevy_mod_billboard::BillboardLockAxisBundle;
+use bevy_mod_billboard::{BillboardLockAxisBundle, BillboardLockAxis};
 use bevy_mod_billboard::prelude::*;
 
 fn main() {
@@ -26,7 +26,10 @@ fn setup_scene(
                 mesh: BillboardMeshHandle(meshes.add(Quad::new(Vec2::new(2., 4.)).into())),
                 ..default()
             },
-            ..default()
+            lock_axis: BillboardLockAxis {
+                y_axis: true,
+                ..Default::default()
+            },
         });
     commands
         .spawn(BillboardTextureBundle {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,13 +26,16 @@ impl Default for BillboardDepth {
 }
 
 #[derive(Default, Clone, Copy, Component, Debug, Reflect)]
-pub struct BillboardLockAxisY;
+pub struct BillboardLockAxis {
+    pub y_axis: bool,
+    pub rotation: bool,
+}
 
 #[derive(Bundle, Default)]
 pub struct BillboardLockAxisBundle<T: Bundle> {
     #[bundle]
     pub billboard_bundle: T,
-    pub lock_axis_y: BillboardLockAxisY,
+    pub lock_axis: BillboardLockAxis,
 }
 
 #[derive(Bundle, Default)]

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -474,31 +474,25 @@ pub fn extract_billboard(
     mut previous_len_lock: Local<usize>,
     mut previous_len_lockless: Local<usize>,
     query_lockless: Extract<
-        Query<
-            (
-                Entity,
-                &ComputedVisibility,
-                &GlobalTransform,
-                &Handle<BillboardTexture>,
-                &BillboardMeshHandle,
-                &BillboardDepth,
-            ),
-            Without<BillboardLockAxis>,
-        >,
+        Query<(
+            Entity,
+            &ComputedVisibility,
+            &GlobalTransform,
+            &Handle<BillboardTexture>,
+            &BillboardMeshHandle,
+            &BillboardDepth,
+        ), Without<BillboardLockAxis>>,
     >,
     query_lock: Extract<
-        Query<
-            (
-                Entity,
-                &ComputedVisibility,
-                &GlobalTransform,
-                &Handle<BillboardTexture>,
-                &BillboardMeshHandle,
-                &BillboardDepth,
-                &BillboardLockAxis,
-            ),
-            With<BillboardLockAxis>,
-        >,
+        Query<(
+            Entity,
+            &ComputedVisibility,
+            &GlobalTransform,
+            &Handle<BillboardTexture>,
+            &BillboardMeshHandle,
+            &BillboardDepth,
+            &BillboardLockAxis,
+        ), With<BillboardLockAxis>>,
     >,
 ) {
     let mut values_lockless = Vec::with_capacity(*previous_len_lockless);

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,4 +1,6 @@
-use crate::{ATTRIBUTE_TEXTURE_ARRAY_INDEX, BILLBOARD_SHADER_HANDLE, BillboardDepth, BillboardLockAxisY};
+use crate::{
+    BillboardDepth, BillboardLockAxis, ATTRIBUTE_TEXTURE_ARRAY_INDEX, BILLBOARD_SHADER_HANDLE,
+};
 
 use bevy::core_pipeline::core_3d::Transparent3d;
 use bevy::ecs::query::ROQueryItem;
@@ -199,6 +201,7 @@ bitflags::bitflags! {
         const TEXTURE            = (1 << 0);
         const DEPTH              = (1 << 1);
         const LOCK_Y             = (1 << 2);
+        const LOCK_ROTATION      = (1 << 3);
         const MSAA_RESERVED_BITS = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
     }
 }
@@ -274,6 +277,7 @@ impl SpecializedMeshPipeline for BillboardPipeline {
         const DEF_VERTEX_COLOR: &str = "VERTEX_COLOR";
         const DEF_VERTEX_TEXTURE_ARRAY: &str = "VERTEX_TEXTURE_ARRAY";
         const DEF_LOCK_Y: &str = "LOCK_Y";
+        const DEF_LOCK_ROTATION: &str = "LOCK_ROTATION";
 
         let mut shader_defs = Vec::with_capacity(4);
         let mut attributes = Vec::with_capacity(4);
@@ -300,6 +304,9 @@ impl SpecializedMeshPipeline for BillboardPipeline {
 
         if key.contains(BillboardPipelineKey::LOCK_Y) {
             shader_defs.push(DEF_LOCK_Y.into());
+        }
+        if key.contains(BillboardPipelineKey::LOCK_ROTATION) {
+            shader_defs.push(DEF_LOCK_ROTATION.into());
         }
 
         Ok(RenderPipelineDescriptor {
@@ -467,25 +474,31 @@ pub fn extract_billboard(
     mut previous_len_lock: Local<usize>,
     mut previous_len_lockless: Local<usize>,
     query_lockless: Extract<
-        Query<(
-            Entity,
-            &ComputedVisibility,
-            &GlobalTransform,
-            &Handle<BillboardTexture>,
-            &BillboardMeshHandle,
-            &BillboardDepth,
-        ), Without<BillboardLockAxisY>>,
+        Query<
+            (
+                Entity,
+                &ComputedVisibility,
+                &GlobalTransform,
+                &Handle<BillboardTexture>,
+                &BillboardMeshHandle,
+                &BillboardDepth,
+            ),
+            Without<BillboardLockAxis>,
+        >,
     >,
     query_lock: Extract<
-        Query<(
-            Entity,
-            &ComputedVisibility,
-            &GlobalTransform,
-            &Handle<BillboardTexture>,
-            &BillboardMeshHandle,
-            &BillboardDepth,
-            &BillboardLockAxisY,
-        ), With<BillboardLockAxisY>>,
+        Query<
+            (
+                Entity,
+                &ComputedVisibility,
+                &GlobalTransform,
+                &Handle<BillboardTexture>,
+                &BillboardMeshHandle,
+                &BillboardDepth,
+                &BillboardLockAxis,
+            ),
+            With<BillboardLockAxis>,
+        >,
     >,
 ) {
     let mut values_lockless = Vec::with_capacity(*previous_len_lockless);
@@ -517,7 +530,7 @@ pub fn extract_billboard(
 
     let mut values_lock = Vec::with_capacity(*previous_len_lock);
 
-    for (entity, visibility, transform, texture_handle, mesh_handle, depth, lock_axis_y) in
+    for (entity, visibility, transform, texture_handle, mesh_handle, depth, lock_axis) in
         query_lock.iter()
     {
         if !visibility.is_visible() {
@@ -525,11 +538,16 @@ pub fn extract_billboard(
         }
 
         // TODO: Maybe reset rotation elsewhere
-        let (scale, _, translation) = transform.to_scale_rotation_translation();
+        let (scale, rotation, translation) = transform.to_scale_rotation_translation();
+        let rotation = if lock_axis.rotation {
+            rotation
+        } else {
+            Quat::default()
+        };
         let transform = Transform {
             translation,
             scale,
-            ..default()
+            rotation,
         }
         .compute_matrix();
 
@@ -540,7 +558,7 @@ pub fn extract_billboard(
                 BillboardMeshHandle(mesh_handle.0.clone_weak()),
                 BillboardUniform { transform },
                 *depth,
-                *lock_axis_y,
+                *lock_axis,
             ),
         ));
     }
@@ -618,7 +636,7 @@ pub fn queue_billboard_texture(
         &BillboardUniform,
         &BillboardMeshHandle,
         &BillboardDepth,
-        Option<&BillboardLockAxisY>,
+        Option<&BillboardLockAxis>,
     )>,
     events: Res<SpriteAssetEvents>,
 ) {
@@ -646,7 +664,7 @@ pub fn queue_billboard_texture(
                        billboard_uniform,
                        billboard_mesh_handle,
                        depth,
-                       lock_axis_y,
+                       lock_axis,
                    )) = billboards.get(*visible_entity) else { continue; };
             let Some(mesh) = render_meshes.get(&billboard_mesh_handle.0) else { continue; };
             let Some(billboard_texture) = billboard_textures.get(billboard_texture_handle) else { continue; };
@@ -663,8 +681,11 @@ pub fn queue_billboard_texture(
                 key |= BillboardPipelineKey::DEPTH;
             }
 
-            if lock_axis_y.is_some() {
+            if lock_axis.map_or(false, |lock| lock.y_axis) {
                 key |= BillboardPipelineKey::LOCK_Y;
+            }
+            if lock_axis.map_or(false, |lock| lock.rotation) {
+                key |= BillboardPipelineKey::LOCK_ROTATION;
             }
 
             let (array_handle, array_image, pipeline_id, texture_layout) = match billboard_type {

--- a/src/shader/billboard.wgsl
+++ b/src/shader/billboard.wgsl
@@ -51,6 +51,9 @@ struct VertexOutput {
 
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
+#ifdef LOCK_ROTATION
+    let position = view.view_proj * billboard.model * vec4<f32>(vertex.position, 1.0);
+#else
     let camera_right = normalize(vec3<f32>(view.view_proj.x.x, view.view_proj.y.x, view.view_proj.z.x));
 #ifdef LOCK_Y
     let camera_up = vec3<f32>(0.0, 1.0, 0.0);
@@ -60,6 +63,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 
     let world_space = camera_right * vertex.position.x + camera_up * vertex.position.y;
     let position = view.view_proj * billboard.model * vec4<f32>(world_space, 1.0);
+#endif
 
     var out: VertexOutput;
     out.position = position;


### PR DESCRIPTION
adds the ability to lock rotation completely, to allow non-billboarded 3d text entities.

i realise this isn't really the point of the crate, but i don't know of an easier way to do simple worldspace 3d text and needed it for my own use. then figured i might as well open the PR in case you want it.