### PR TITLE
Upgrade bevy to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ smallvec = "1.11.0"
 bitflags = "2.3"
 
 [dependencies.bevy]
-version = "0.13"
-default_features = false
+version = "0.14.0-rc.2"
+default-features = false
 features = [
     "bevy_core_pipeline",
     "bevy_render",
@@ -34,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.13"
+bevy = "0.14.0-rc.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.11.0"
 bitflags = "2.3"
 
 [dependencies.bevy]
-version = "0.14.0-rc.2"
+version = "0.14"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -34,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.14.0-rc.2"
+bevy = "0.14"

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::BillboardDepth;
@@ -69,7 +69,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(css::BEIGE)),
+        material: materials.add(Color::Srgba(palettes::css::BEIGE)),
         transform: Transform::from_translation(Vec3::new(1., 0., 0.)),
         ..default()
     });

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::BillboardDepth;
@@ -68,7 +69,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::BEIGE),
+        material: materials.add(Color::Srgba(css::BEIGE)),
         transform: Transform::from_translation(Vec3::new(1., 0., 0.)),
         ..default()
     });

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::BillboardLockAxis;
@@ -23,7 +24,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: TextStyle {
                         font_size: 60.0,
                         font: fira_sans_regular_handle.clone(),
-                        color: Color::ORANGE,
+                        color: Color::Srgba(css::ORANGE),
                     },
                 },
                 TextSection {
@@ -67,7 +68,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::GRAY),
+        material: materials.add(Color::Srgba(css::GRAY)),
         transform: Transform::from_translation(Vec3::NEG_Y),
         ..default()
     });

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::BillboardLockAxis;
@@ -24,7 +24,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: TextStyle {
                         font_size: 60.0,
                         font: fira_sans_regular_handle.clone(),
-                        color: Color::Srgba(css::ORANGE),
+                        color: Color::Srgba(palettes::css::ORANGE),
                     },
                 },
                 TextSection {
@@ -68,7 +68,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(css::GRAY)),
+        material: materials.add(Color::Srgba(palettes::css::GRAY)),
         transform: Transform::from_translation(Vec3::NEG_Y),
         ..default()
     });

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::{BillboardLockAxis, BillboardLockAxisBundle};
@@ -49,8 +50,8 @@ fn setup_scene(
 ) {
     commands.spawn(PbrBundle {
         transform: Transform::from_scale(Vec3::splat(3.0)),
-        mesh: meshes.add(Plane3d::new(Vec3::Y)),
-        material: materials.add(Color::SILVER),
+        mesh: meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5))),
+        material: materials.add(Color::Srgba(css::SILVER)),
         ..default()
     });
 

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 use bevy_mod_billboard::{BillboardLockAxis, BillboardLockAxisBundle};
@@ -51,7 +51,7 @@ fn setup_scene(
     commands.spawn(PbrBundle {
         transform: Transform::from_scale(Vec3::splat(3.0)),
         mesh: meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5))),
-        material: materials.add(Color::Srgba(css::SILVER)),
+        material: materials.add(Color::Srgba(palettes::css::SILVER)),
         ..default()
     });
 

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -13,7 +13,7 @@
 //! and recompute them every frame.
 
 use bevy::{
-    color::palettes::css,
+    color::palettes,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
 };
@@ -68,7 +68,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut meshes: Res
                             TextStyle {
                                 font_size: 60.0,
                                 font: fira_sans_regular_handle.clone(),
-                                color: Color::Srgba(css::ORANGE),
+                                color: Color::Srgba(palettes::css::ORANGE),
                             },
                         ),
                         ..default()

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -13,6 +13,7 @@
 //! and recompute them every frame.
 
 use bevy::{
+    color::palettes::css,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
 };
@@ -67,7 +68,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut meshes: Res
                             TextStyle {
                                 font_size: 60.0,
                                 font: fira_sans_regular_handle.clone(),
-                                color: Color::ORANGE,
+                                color: Color::Srgba(css::ORANGE),
                             },
                         ),
                         ..default()

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -21,7 +21,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font_size: 60.0,
                     font: fira_sans_regular_handle.clone(),
-                    color: Color::Srgba(css::ORANGE),
+                    color: Color::Srgba(palettes::css::ORANGE),
                 },
             },
             TextSection {
@@ -60,7 +60,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::LinearRgba(LinearRgba::new(0.7, 0.7, 0.7, 1.0))), // gray
+        material: materials.add(Color::Srgba(palettes::css::GRAY)),
         transform: Transform::from_translation(Vec3::NEG_Y),
         ..default()
     });

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -20,7 +21,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font_size: 60.0,
                     font: fira_sans_regular_handle.clone(),
-                    color: Color::ORANGE,
+                    color: Color::Srgba(css::ORANGE),
                 },
             },
             TextSection {
@@ -59,7 +60,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::GRAY),
+        material: materials.add(Color::LinearRgba(LinearRgba::new(0.7, 0.7, 0.7, 1.0))), // gray
         transform: Transform::from_translation(Vec3::NEG_Y),
         ..default()
     });

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -46,7 +46,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(css::GRAY)),
+        material: materials.add(Color::Srgba(palettes::css::GRAY)),
         transform: Transform::from_translation(Vec3::NEG_Y * 2.),
         ..default()
     });

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -45,7 +46,7 @@ fn setup_scene(
 
     commands.spawn(PbrBundle {
         mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::GRAY),
+        material: materials.add(Color::Srgba(css::GRAY)),
         transform: Transform::from_translation(Vec3::NEG_Y * 2.),
         ..default()
     });

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -1,3 +1,4 @@
+use bevy::color::palettes::css;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -25,7 +26,7 @@ fn setup_billboard(
         .spawn((
             PbrBundle {
                 mesh: meshes.add(Cuboid::default()),
-                material: materials.add(Color::GRAY),
+                material: materials.add(Color::Srgba(css::GRAY)),
                 transform: Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
                 ..default()
             },

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -1,4 +1,4 @@
-use bevy::color::palettes::css;
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
 
@@ -26,7 +26,7 @@ fn setup_billboard(
         .spawn((
             PbrBundle {
                 mesh: meshes.add(Cuboid::default()),
-                material: materials.add(Color::Srgba(css::GRAY)),
+                material: materials.add(Color::Srgba(palettes::css::GRAY)),
                 transform: Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
                 ..default()
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ impl Default for BillboardDepth {
 }
 
 #[derive(Default, Clone, Copy, Component, Debug, Reflect)]
+pub struct Billboard;
+
+#[derive(Default, Clone, Copy, Component, Debug, Reflect)]
 pub struct BillboardLockAxis {
     pub y_axis: bool,
     pub rotation: bool,
@@ -42,6 +45,7 @@ pub struct BillboardLockAxisBundle<T: Bundle> {
 
 #[derive(Bundle, Default)]
 pub struct BillboardTextureBundle {
+    pub billboard: Billboard,
     pub mesh: BillboardMeshHandle,
     pub texture: BillboardTextureHandle,
     pub transform: Transform,
@@ -54,6 +58,7 @@ pub struct BillboardTextureBundle {
 
 #[derive(Bundle, Default)]
 pub struct BillboardTextBundle {
+    pub billboard: Billboard,
     pub text: Text,
     pub text_bounds: BillboardTextBounds,
     pub text_anchor: Anchor,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -153,7 +153,7 @@ pub fn queue_billboard_texture(
     transparent_draw_functions: Res<DrawFunctions<Transparent3d>>,
     msaa: Res<Msaa>,
     billboard_pipeline: Res<BillboardPipeline>,
-    (gpu_images, gpu_meshes): (Res<RenderAssets<Image>>, Res<RenderAssets<Mesh>>),
+    (gpu_images, gpu_meshes): (Res<RenderAssets<GpuImage>>, Res<RenderAssets<GpuMesh>>),
     events: Res<SpriteAssetEvents>,
     billboards: Query<(
         &BillboardUniform,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -12,11 +12,11 @@ use bevy::prelude::{
     ResMut, Resource, With, World,
 };
 use bevy::render::extract_component::{ComponentUniforms, DynamicUniformIndex};
-use bevy::render::mesh::{GpuBufferInfo, MeshVertexBufferLayout, PrimitiveTopology};
+use bevy::render::mesh::{GpuBufferInfo, GpuMesh, MeshVertexBufferLayoutRef, PrimitiveTopology};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
-    DrawFunctions, RenderCommand, RenderCommandResult, RenderPhase, SetItemPipeline,
-    TrackedRenderPass,
+    DrawFunctions, PhaseItemExtraIndex, RenderCommand, RenderCommandResult, SetItemPipeline,
+    TrackedRenderPass, ViewSortedRenderPhases,
 };
 use bevy::render::render_resource::{
     BindGroup, BindGroupEntry, BindGroupLayout, BindGroupLayoutEntry, BindingResource, BindingType,
@@ -27,7 +27,7 @@ use bevy::render::render_resource::{
     SpecializedMeshPipelines, TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
 };
 use bevy::render::renderer::RenderDevice;
-use bevy::render::texture::BevyDefault;
+use bevy::render::texture::{BevyDefault, GpuImage};
 use bevy::render::view::{
     ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities,
 };
@@ -144,11 +144,8 @@ pub fn prepare_billboard_bind_group(
 }
 
 pub fn queue_billboard_texture(
-    mut views: Query<(
-        &ExtractedView,
-        &VisibleEntities,
-        &mut RenderPhase<Transparent3d>,
-    )>,
+    mut views: Query<(Entity, &ExtractedView, &VisibleEntities)>,
+    mut transparent_render_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
     mut pipeline_cache: ResMut<PipelineCache>,
     mut image_bind_groups: ResMut<BillboardImageBindGroups>,
     mut billboard_pipelines: ResMut<SpecializedMeshPipelines<BillboardPipeline>>,
@@ -177,7 +174,11 @@ pub fn queue_billboard_texture(
         };
     }
 
-    for (view, visible_entities, mut transparent_phase) in &mut views {
+    for (view_entity, view, visible_entities) in &mut views {
+        let Some(transparent_phase) = transparent_render_phases.get_mut(&view_entity) else {
+            continue;
+        };
+
         let draw_transparent_billboard = transparent_draw_functions
             .read()
             .get_id::<DrawBillboard>()
@@ -185,76 +186,78 @@ pub fn queue_billboard_texture(
 
         let rangefinder = view.rangefinder3d();
 
-        for visible_entity in &visible_entities.entities {
-            let Ok((uniform, mesh, image, billboard)) = billboards.get(*visible_entity) else {
-                continue;
-            };
-            let Some(gpu_image) = gpu_images.get(image.id) else {
-                continue;
-            };
-            let Some(gpu_mesh) = gpu_meshes.get(mesh.id) else {
-                continue;
-            };
-
-            let mut key = BillboardPipelineKey::from_msaa_samples(msaa.samples());
-
-            if billboard.depth.0 {
-                key |= BillboardPipelineKey::DEPTH;
-            }
-
-            if billboard.lock_axis.map_or(false, |lock| lock.y_axis) {
-                key |= BillboardPipelineKey::LOCK_Y;
-            }
-            if billboard.lock_axis.map_or(false, |lock| lock.rotation) {
-                key |= BillboardPipelineKey::LOCK_ROTATION;
-            }
-
-            if view.hdr {
-                key |= BillboardPipelineKey::HDR;
-            }
-
-            let pipeline_id = billboard_pipelines.specialize(
-                &mut pipeline_cache,
-                &billboard_pipeline,
-                key,
-                &gpu_mesh.layout,
-            );
-
-            let pipeline_id = match pipeline_id {
-                Ok(id) => id,
-                Err(err) => {
-                    error!("{err:?}");
+        for (_type_id, visible_entities) in &visible_entities.entities {
+            for visible_entity in visible_entities {
+                let Ok((uniform, mesh, image, billboard)) = billboards.get(*visible_entity) else {
                     continue;
+                };
+                let Some(gpu_image) = gpu_images.get(image.id) else {
+                    continue;
+                };
+                let Some(gpu_mesh) = gpu_meshes.get(mesh.id) else {
+                    continue;
+                };
+
+                let mut key = BillboardPipelineKey::from_msaa_samples(msaa.samples());
+
+                if billboard.depth.0 {
+                    key |= BillboardPipelineKey::DEPTH;
                 }
-            };
 
-            let distance = rangefinder.distance(&uniform.transform);
+                if billboard.lock_axis.map_or(false, |lock| lock.y_axis) {
+                    key |= BillboardPipelineKey::LOCK_Y;
+                }
+                if billboard.lock_axis.map_or(false, |lock| lock.rotation) {
+                    key |= BillboardPipelineKey::LOCK_ROTATION;
+                }
 
-            image_bind_groups.values.entry(image.id).or_insert_with(|| {
-                render_device.create_bind_group(
-                    Some("billboard_texture_bind_group"),
-                    &billboard_pipeline.texture_layout,
-                    &[
-                        BindGroupEntry {
-                            binding: 0,
-                            resource: BindingResource::TextureView(&gpu_image.texture_view),
-                        },
-                        BindGroupEntry {
-                            binding: 1,
-                            resource: BindingResource::Sampler(&gpu_image.sampler),
-                        },
-                    ],
-                )
-            });
+                if view.hdr {
+                    key |= BillboardPipelineKey::HDR;
+                }
 
-            transparent_phase.add(Transparent3d {
-                pipeline: pipeline_id,
-                entity: *visible_entity,
-                draw_function: draw_transparent_billboard,
-                batch_range: 0..1,
-                dynamic_offset: None,
-                distance,
-            });
+                let pipeline_id = billboard_pipelines.specialize(
+                    &mut pipeline_cache,
+                    &billboard_pipeline,
+                    key,
+                    &gpu_mesh.layout,
+                );
+
+                let pipeline_id = match pipeline_id {
+                    Ok(id) => id,
+                    Err(err) => {
+                        error!("{err:?}");
+                        continue;
+                    }
+                };
+
+                let distance = rangefinder.distance(&uniform.transform);
+
+                image_bind_groups.values.entry(image.id).or_insert_with(|| {
+                    render_device.create_bind_group(
+                        Some("billboard_texture_bind_group"),
+                        &billboard_pipeline.texture_layout,
+                        &[
+                            BindGroupEntry {
+                                binding: 0,
+                                resource: BindingResource::TextureView(&gpu_image.texture_view),
+                            },
+                            BindGroupEntry {
+                                binding: 1,
+                                resource: BindingResource::Sampler(&gpu_image.sampler),
+                            },
+                        ],
+                    )
+                });
+
+                transparent_phase.add(Transparent3d {
+                    pipeline: pipeline_id,
+                    entity: *visible_entity,
+                    draw_function: draw_transparent_billboard,
+                    batch_range: 0..1,
+                    extra_index: PhaseItemExtraIndex::NONE,
+                    distance,
+                });
+            }
         }
     }
 }
@@ -336,7 +339,7 @@ impl SpecializedMeshPipeline for BillboardPipeline {
     fn specialize(
         &self,
         key: Self::Key,
-        layout: &MeshVertexBufferLayout,
+        layout: &MeshVertexBufferLayoutRef,
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         const DEF_VERTEX_COLOR: &str = "VERTEX_COLOR";
         const DEF_LOCK_Y: &str = "LOCK_Y";
@@ -347,6 +350,8 @@ impl SpecializedMeshPipeline for BillboardPipeline {
 
         attributes.push(Mesh::ATTRIBUTE_POSITION.at_shader_location(0));
         attributes.push(Mesh::ATTRIBUTE_UV_0.at_shader_location(1));
+
+        let layout = layout.0.as_ref();
 
         if layout.contains(Mesh::ATTRIBUTE_COLOR) {
             shader_defs.push(DEF_VERTEX_COLOR.into());
@@ -504,7 +509,7 @@ impl<const I: usize> RenderCommand<Transparent3d> for SetBillboardTextureBindGro
 
 pub struct DrawBillboardMesh;
 impl RenderCommand<Transparent3d> for DrawBillboardMesh {
-    type Param = SRes<RenderAssets<Mesh>>;
+    type Param = SRes<RenderAssets<GpuMesh>>;
     type ViewQuery = ();
     type ItemQuery = Read<RenderBillboardMesh>;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,7 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout};
+use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
 use crate::texture::extract_billboard_texture;
 use crate::{
     BillboardMeshHandle, BillboardTextBounds, BillboardTextureHandle, BILLBOARD_SHADER_HANDLE,
@@ -12,6 +12,8 @@ use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::UniformComponentPlugin;
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
+use bevy::render::view::check_visibility;
+use bevy::render::view::VisibilitySystems::CheckVisibility;
 use bevy::render::{RenderApp, RenderSet};
 use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
 
@@ -32,7 +34,11 @@ impl Plugin for BillboardPlugin {
             .register_type::<BillboardTextBounds>()
             .add_systems(
                 PostUpdate,
-                update_billboard_text_layout.ambiguous_with(CameraUpdateSystem),
+                (
+                    update_billboard_text_layout.ambiguous_with(CameraUpdateSystem),
+                    check_visibility::<With<BillboardMeshHandle>>.in_set(CheckVisibility),
+                    check_visibility::<With<BillboardTextHandles>>.in_set(CheckVisibility),
+                ),
             );
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,10 +2,11 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
+use crate::text::{extract_billboard_text, update_billboard_text_layout};
 use crate::texture::extract_billboard_texture;
 use crate::{
-    BillboardMeshHandle, BillboardTextBounds, BillboardTextureHandle, BILLBOARD_SHADER_HANDLE,
+    Billboard, BillboardMeshHandle, BillboardTextBounds, BillboardTextureHandle,
+    BILLBOARD_SHADER_HANDLE,
 };
 use bevy::prelude::*;
 use bevy::render::camera::CameraUpdateSystem;
@@ -36,8 +37,7 @@ impl Plugin for BillboardPlugin {
                 PostUpdate,
                 (
                     update_billboard_text_layout.ambiguous_with(CameraUpdateSystem),
-                    check_visibility::<With<BillboardMeshHandle>>.in_set(CheckVisibility),
-                    check_visibility::<With<BillboardTextHandles>>.in_set(CheckVisibility),
+                    check_visibility::<With<Billboard>>.in_set(CheckVisibility),
                 ),
             );
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,6 +1,7 @@
 use crate::pipeline::{RenderBillboardImage, RenderBillboardMesh};
 use crate::utils::calculate_billboard_uniform;
 use crate::{BillboardDepth, BillboardLockAxis};
+use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy::render::mesh::{Indices, PrimitiveTopology};
 use bevy::render::render_asset::RenderAssetUsages;
@@ -169,7 +170,7 @@ pub fn update_billboard_text_layout(
                 let mut colors = Vec::with_capacity(info.glyphs.len() * 4);
                 let mut indices = Vec::with_capacity(info.glyphs.len() * 6);
 
-                let mut color = Color::WHITE.linear().to_f32_array();
+                let mut color = palettes::css::WHITE.to_f32_array();
                 let mut current_section = usize::MAX;
 
                 for PositionedGlyph {
@@ -210,7 +211,7 @@ pub fn update_billboard_text_layout(
                         color = text.sections[section_index]
                             .style
                             .color
-                            .linear()
+                            .to_linear()
                             .to_f32_array();
                         current_section = section_index;
                     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -169,7 +169,7 @@ pub fn update_billboard_text_layout(
                 let mut colors = Vec::with_capacity(info.glyphs.len() * 4);
                 let mut indices = Vec::with_capacity(info.glyphs.len() * 6);
 
-                let mut color = Color::WHITE.as_linear_rgba_f32();
+                let mut color = Color::WHITE.linear().to_f32_array();
                 let mut current_section = usize::MAX;
 
                 for PositionedGlyph {
@@ -194,9 +194,10 @@ pub fn update_billboard_text_layout(
                         [bottom_right.x, top_left.y, 0.0],
                     ]);
 
-                    let Rect { min, max } = atlas.textures[atlas_info.glyph_index];
-                    let min = min / atlas.size;
-                    let max = max / atlas.size;
+                    let URect { min, max } = atlas.textures[atlas_info.glyph_index];
+                    let atlas_size = atlas.size.as_vec2();
+                    let min = min.as_vec2() / atlas_size;
+                    let max = max.as_vec2() / atlas_size;
 
                     uvs.extend([
                         [min.x, max.y],
@@ -209,7 +210,8 @@ pub fn update_billboard_text_layout(
                         color = text.sections[section_index]
                             .style
                             .color
-                            .as_linear_rgba_f32();
+                            .linear()
+                            .to_f32_array();
                         current_section = section_index;
                     }
 


### PR DESCRIPTION
Hey, I upgraded bevy to the new version although we might want to wait until 0.14 is officially released to merge it in. These were the main changes (but I might've missed one or two):

- https://github.com/bevyengine/bevy/pull/12067 New color palette
- https://github.com/bevyengine/bevy/pull/12827 `RenderAssets<Image>` is now `RenderAssets<GpuImage>` 
- https://github.com/bevyengine/bevy/pull/13277 `RenderPhase`s are now stored in a resource `ViewSortedRenderPhases`
- https://github.com/bevyengine/bevy/pull/12216 `MeshVertexBufferLayout` is now `MeshVertexBufferLayoutRef`
- https://github.com/bevyengine/bevy/pull/11698 Image dimensions are now in `UVec2`s
- https://github.com/bevyengine/bevy/pull/12582 We have to explicitly add custom text/mesh handle components to the `CheckVisibility` schedule

Thanks!