### PR TITLE
Migrate to Bevy 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,8 @@ exclude = [ "images", "assets" ]
 smallvec = "1.11.0"
 bitflags = "2.3"
 
-# see bevy #16563
-bevy_internal = { version = "0.15", features = ["bevy_image"] }
-
 [dependencies.bevy]
-version = "0.15"
+version = "0.16"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -37,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.15"
+bevy = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.11.0"
 bitflags = "2.3"
 
 [dependencies.bevy]
-version = "0.14"
+version = "0.15"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -34,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ exclude = [ "images", "assets" ]
 smallvec = "1.11.0"
 bitflags = "2.3"
 
+# see bevy #16563
+bevy_internal = { version = "0.15", features = ["bevy_image"] }
+
 [dependencies.bevy]
 version = "0.15"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -40,39 +40,31 @@ App::new()
 
 Text:
 ```rs
-commands.spawn(BillboardTextBundle {
-    transform: Transform::from_translation(Vec3::new(0., 2., 0.))
-        .with_scale(Vec3::splat(0.0085)),
-    text: Text::from_sections([
-        TextSection {
-            value: "IMPORTANT".to_string(),
-            style: TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::ORANGE,
-            }
-        },
-        TextSection {
-            value: " text".to_string(),
-            style: TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            }
-        }
-    ]).with_alignment(TextAlignment::CENTER),
-    ..default()
-});
+commands
+    .spawn((
+        BillboardText::default(),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_scale(Vec3::splat(0.0085)),
+    ))
+    .with_child((
+        TextSpan::new("IMPORTANT"),
+        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextColor::from(Color::Srgba(palettes::css::ORANGE)),
+    ))
+    .with_child((
+        TextSpan::new(" text"),
+        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextColor::from(Color::WHITE),
+    ));
 ```
 
 Texture:
 ```rs
-commands.spawn(BillboardTextureBundle {
-    transform: Transform::from_translation(Vec3::new(0., 5., 0.)),
-    texture: BillboardTextureHandle(handle.clone()),
-    mesh: BillboardMeshHandle(meshes.add(Quad::new(Vec2::new(4.0, 4.0)).into()).into()),
-    ..default()
-});
+commands.spawn((
+    BillboardTexture(image_handle.clone()),
+    BillboardMesh(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
+    Transform::from_xyz(0.0, 5.0, 0.0),
+));
 ```
 
 Full examples at [examples](examples).

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -61,7 +61,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
-use bevy_mod_billboard::BillboardDepth;
 
 fn main() {
     App::new()
@@ -15,41 +14,31 @@ fn main() {
 const TEXT_SCALE: Vec3 = Vec3::splat(0.0085);
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
+    let text_font =
+        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
 
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_translation(Vec3::new(0., 0.5, 0.)).with_scale(TEXT_SCALE),
-        text: Text::from_section(
-            "depth enabled",
-            TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            },
-        )
-        .with_justify(JustifyText::Center),
-        ..default()
-    });
+    commands.spawn((
+        BillboardText::new("depth enabled"),
+        text_font.clone(),
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_xyz(0.0, 0.5, 0.0).with_scale(TEXT_SCALE),
+    ));
 
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_translation(Vec3::new(0., -0.5, 0.)).with_scale(TEXT_SCALE),
-        text: Text::from_section(
-            "depth disabled",
-            TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            },
-        )
-        .with_justify(JustifyText::Center),
-        billboard_depth: BillboardDepth(false),
-        ..default()
-    });
+    commands.spawn((
+        BillboardText::new("depth disabled"),
+        BillboardDepth(false),
+        text_font.clone(),
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_xyz(0.0, -0.5, 0.0).with_scale(TEXT_SCALE),
+    ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -57,26 +46,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::BEIGE)),
-        transform: Transform::from_translation(Vec3::new(1., 0., 0.)),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::BEIGE))),
+        Transform::from_xyz(1., 0., 0.),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -33,7 +33,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -56,7 +56,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
-use bevy_mod_billboard::BillboardLockAxis;
 
 fn main() {
     App::new()
@@ -13,42 +12,28 @@ fn main() {
 }
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
-    commands.spawn((
-        BillboardTextBundle {
-            transform: Transform::from_scale(Vec3::splat(0.0085))
-                .looking_at(Vec3::splat(5.0), Vec3::Y),
-            text: Text::from_sections([
-                TextSection {
-                    value: "LOCKED".to_string(),
-                    style: TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::Srgba(palettes::css::ORANGE),
-                    },
-                },
-                TextSection {
-                    value: " text".to_string(),
-                    style: TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::WHITE,
-                    },
-                },
-            ])
-            .with_justify(JustifyText::Center),
-            ..default()
-        },
-        BillboardLockAxis {
-            rotation: true,
-            ..default()
-        },
-    ));
+    let text_font =
+        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
+
+    commands
+        .spawn((
+            BillboardText::default(),
+            TextLayout::new_with_justify(JustifyText::Center),
+            Transform::from_scale(Vec3::splat(0.0085)).looking_at(Vec3::splat(5.0), Vec3::Y),
+            BillboardLockAxis::from_lock_rotation(true),
+        ))
+        .with_child((
+            TextSpan::new("LOCKED"),
+            text_font.clone(),
+            TextColor(Color::Srgba(palettes::css::ORANGE)),
+        ))
+        .with_child((TextSpan::new(" text"), text_font, TextColor(Color::WHITE)));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -56,26 +41,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -35,7 +35,7 @@ fn setup_billboard(
 // Important bits are above, the code below is for camera, reference plane and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -58,7 +58,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -28,7 +28,7 @@ fn setup_billboard(
     commands.spawn((
         BillboardTexture(image_handle),
         BillboardMesh(meshes.add(Rectangle::new(2.0, 4.0))),
-        Transform::from_xyz(2.0, 2.0, 0.0),
+        Transform::from_xyz(-2.0, 2.0, 0.0),
     ));
 }
 

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -35,7 +35,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -58,7 +58,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -13,34 +13,29 @@ fn main() {
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
     let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_scale(Vec3::splat(0.0085)),
-        text: Text::from_sections([
-            TextSection {
-                value: "IMPORTANT".to_string(),
-                style: TextStyle {
-                    font_size: 60.0,
-                    font: fira_sans_regular_handle.clone(),
-                    color: Color::Srgba(palettes::css::ORANGE),
-                },
-            },
-            TextSection {
-                value: " text".to_string(),
-                style: TextStyle {
-                    font_size: 60.0,
-                    font: fira_sans_regular_handle.clone(),
-                    color: Color::WHITE,
-                },
-            },
-        ])
-        .with_justify(JustifyText::Center),
-        ..default()
-    });
+
+    commands
+        .spawn((
+            BillboardText::default(),
+            TextLayout::new_with_justify(JustifyText::Left),
+            Transform::from_scale(Vec3::splat(0.0085)),
+        ))
+        .with_child((
+            TextSpan::new("IMPORTANT"),
+            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextColor::from(Color::Srgba(palettes::css::ORANGE)),
+        ))
+        .with_child((
+            TextSpan::new(" text"),
+            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextColor::from(Color::WHITE),
+        ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -48,26 +43,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -26,7 +26,7 @@ fn setup_billboard(
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -49,7 +49,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -17,16 +17,16 @@ fn setup_billboard(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image_handle = asset_server.load("rust-logo-256x256.png");
-    commands.spawn(BillboardTextureBundle {
-        texture: BillboardTextureHandle(image_handle),
-        mesh: BillboardMeshHandle(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
-        ..default()
-    });
+    commands.spawn((
+        BillboardTexture(image_handle.clone()),
+        BillboardMesh(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
+    ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -34,26 +34,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y * 2.),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y * 2.),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -53,7 +53,7 @@ fn move_cube(
     mut direction: Local<bool>,
     time: Res<Time>,
 ) {
-    let mut parent_cube = parent_cube.single_mut();
+    let mut parent_cube = parent_cube.single_mut().unwrap();
 
     let direction_vec = if *direction { Vec3::Z } else { Vec3::NEG_Z };
 
@@ -62,6 +62,6 @@ fn move_cube(
 
     if *accumulated >= 2.0 {
         *direction = !*direction;
-        *accumulated = *accumulated - 2.0
+        *accumulated -= 2.0
     }
 }

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -24,40 +24,27 @@ fn setup_billboard(
 
     commands
         .spawn((
-            PbrBundle {
-                mesh: meshes.add(Cuboid::default()),
-                material: materials.add(Color::Srgba(palettes::css::GRAY)),
-                transform: Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
-                ..default()
-            },
             ParentCube,
+            Mesh3d(meshes.add(Cuboid::default())),
+            MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+            Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
         ))
-        .with_children(|parent| {
-            parent.spawn(BillboardTextBundle {
-                transform: Transform::from_translation(Vec3::new(0., 1.0, 0.))
-                    .with_scale(Vec3::splat(0.0085)),
-                text: Text::from_section(
-                    "parented text",
-                    TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::WHITE,
-                    },
-                )
-                .with_justify(JustifyText::Center),
-                ..default()
-            });
-        });
+        .with_child((
+            BillboardText::new("parented text"),
+            TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0),
+            TextColor(Color::WHITE),
+            Transform::from_xyz(0.0, 1.0, 0.0).with_scale(Vec3::splat(0.0085)),
+            TextLayout::new_with_justify(JustifyText::Center),
+        ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 fn setup_scene(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-            .looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(5.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn move_cube(
@@ -70,8 +57,8 @@ fn move_cube(
 
     let direction_vec = if *direction { Vec3::Z } else { Vec3::NEG_Z };
 
-    parent_cube.translation += time.delta_seconds() * direction_vec;
-    *accumulated += time.delta_seconds();
+    parent_cube.translation += time.delta_secs() * direction_vec;
+    *accumulated += time.delta_secs();
 
     if *accumulated >= 2.0 {
         *direction = !*direction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+
 pub mod pipeline;
 pub mod plugin;
 pub mod text;
@@ -5,13 +8,15 @@ pub mod texture;
 mod utils;
 
 use crate::text::{BillboardTextBounds, BillboardTextHandles};
+use bevy::asset::weak_handle;
 use bevy::prelude::*;
 use bevy::render::extract_component::ExtractComponent;
+use bevy::render::view::{add_visibility_class, VisibilityClass};
 use bevy::sprite::Anchor;
 use bevy::text::{TextRoot, TextSpanAccess};
 
-pub(self) const BILLBOARD_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(12823766040132746076);
+const BILLBOARD_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("69c21ac3-19fa-4663-aef8-7b4e8f1a6e61");
 
 /// Marker component for a billboarded texture.
 ///
@@ -94,7 +99,8 @@ impl Default for BillboardDepth {
 }
 
 #[derive(Default, Clone, Copy, Component, ExtractComponent, Debug, Reflect)]
-#[require(BillboardDepth)]
+#[require(BillboardDepth, VisibilityClass)]
+#[component(on_add = add_visibility_class::<Billboard>)]
 pub struct Billboard;
 
 #[derive(Default, Clone, Copy, Component, Debug, Reflect)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ impl From<String> for BillboardText {
     }
 }
 
+#[derive(Clone, Component, Default)]
+#[component(storage = "SparseSet")]
+struct BillboardTextNeedsRerender;
+
 #[derive(Clone, Component, Reflect, Default)]
 #[reflect(Component)]
 pub struct BillboardMesh(pub Handle<Mesh>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub struct BillboardTexture(pub Handle<Image>);
 ///
 /// # Warning
 ///
-/// This component is incompatible with [`Text`] and [`Text2d`]!
-/// Bevy will attempt to render the `Text` in the UI and `Text2D` as 2D
+/// This component is incompatible with Bevy's `Text` and `Text2d`!
+/// Bevy will attempt to render the `Text` in the UI and `Text2d` as 2D
 /// text, corrupting the internal `TextLayoutInfo` used by billboarding.
 ///
 /// If you are not using `TextSpan` children, set the `String` field of

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -13,8 +13,6 @@ use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
-use bevy::render::view::check_visibility;
-use bevy::render::view::VisibilitySystems::CheckVisibility;
 use bevy::render::{RenderApp, RenderSet};
 use bevy::text::detect_text_needs_rerender;
 use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
@@ -40,16 +38,13 @@ impl Plugin for BillboardPlugin {
                 PostUpdate,
                 (
                     (
-                        (
-                            detect_text_needs_rerender::<BillboardText>,
-                            detect_billboard_text_color_change,
-                        ),
-                        update_billboard_text_layout,
-                    )
-                        .chain()
-                        .ambiguous_with(CameraUpdateSystem),
-                    check_visibility::<With<Billboard>>.in_set(CheckVisibility),
-                ),
+                        detect_text_needs_rerender::<BillboardText>,
+                        detect_billboard_text_color_change,
+                    ),
+                    update_billboard_text_layout,
+                )
+                    .chain()
+                    .ambiguous_with(CameraUpdateSystem),
             );
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,9 +4,7 @@ use crate::pipeline::{
 };
 use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
 use crate::texture::extract_billboard_texture;
-use crate::{
-    Billboard, BillboardMesh, BillboardTextBounds, BillboardTexture, BILLBOARD_SHADER_HANDLE,
-};
+use crate::{prelude::*, Billboard, BILLBOARD_SHADER_HANDLE};
 use bevy::prelude::*;
 use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
@@ -15,6 +13,7 @@ use bevy::render::render_resource::SpecializedMeshPipelines;
 use bevy::render::view::check_visibility;
 use bevy::render::view::VisibilitySystems::CheckVisibility;
 use bevy::render::{RenderApp, RenderSet};
+use bevy::text::detect_text_needs_rerender;
 use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
 
 pub struct BillboardPlugin;
@@ -37,7 +36,12 @@ impl Plugin for BillboardPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    update_billboard_text_layout.ambiguous_with(CameraUpdateSystem),
+                    (
+                        detect_text_needs_rerender::<BillboardText>,
+                        update_billboard_text_layout,
+                    )
+                        .chain()
+                        .ambiguous_with(CameraUpdateSystem),
                     check_visibility::<With<Billboard>>.in_set(CheckVisibility),
                 ),
             );

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,10 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
+use crate::text::{
+    detect_billboard_text_color_change, extract_billboard_text, update_billboard_text_layout,
+    BillboardTextHandles,
+};
 use crate::texture::extract_billboard_texture;
 use crate::{prelude::*, Billboard, BILLBOARD_SHADER_HANDLE};
 use bevy::prelude::*;
@@ -37,7 +40,10 @@ impl Plugin for BillboardPlugin {
                 PostUpdate,
                 (
                     (
-                        detect_text_needs_rerender::<BillboardText>,
+                        (
+                            detect_text_needs_rerender::<BillboardText>,
+                            detect_billboard_text_color_change,
+                        ),
                         update_billboard_text_layout,
                     )
                         .chain()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,15 +2,14 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout};
+use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
 use crate::texture::extract_billboard_texture;
 use crate::{
-    Billboard, BillboardMeshHandle, BillboardTextBounds, BillboardTextureHandle,
-    BILLBOARD_SHADER_HANDLE,
+    Billboard, BillboardMesh, BillboardTextBounds, BillboardTexture, BILLBOARD_SHADER_HANDLE,
 };
 use bevy::prelude::*;
 use bevy::render::camera::CameraUpdateSystem;
-use bevy::render::extract_component::UniformComponentPlugin;
+use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
 use bevy::render::view::check_visibility;
@@ -30,9 +29,11 @@ impl Plugin for BillboardPlugin {
         );
 
         app.add_plugins(UniformComponentPlugin::<BillboardUniform>::default())
-            .register_type::<BillboardMeshHandle>()
-            .register_type::<BillboardTextureHandle>()
+            .add_plugins(ExtractComponentPlugin::<Billboard>::default())
+            .register_type::<BillboardMesh>()
+            .register_type::<BillboardTexture>()
             .register_type::<BillboardTextBounds>()
+            .register_type::<BillboardTextHandles>()
             .add_systems(
                 PostUpdate,
                 (

--- a/src/shader/billboard.wgsl
+++ b/src/shader/billboard.wgsl
@@ -45,11 +45,11 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let vertex_position = vec4<f32>(-vertex.position.x, vertex.position.y, vertex.position.z, 1.0);
     let position = view.view_proj * billboard.model * vertex_position;
 #else
-    let camera_right = normalize(vec3<f32>(view.view_proj.x.x, view.view_proj.y.x, view.view_proj.z.x));
+    let camera_right = normalize(vec3<f32>(view.view_proj[0][0], view.view_proj[1][0], view.view_proj[2][0]));
 #ifdef LOCK_Y
     let camera_up = vec3<f32>(0.0, 1.0, 0.0);
 #else
-    let camera_up = normalize(vec3<f32>(view.view_proj.x.y, view.view_proj.y.y, view.view_proj.z.y));
+    let camera_up = normalize(vec3<f32>(view.view_proj[0][1], view.view_proj[1][1], view.view_proj[2][1]));
 #endif
 
     let world_space = camera_right * vertex.position.x + camera_up * vertex.position.y;

--- a/src/text.rs
+++ b/src/text.rs
@@ -38,7 +38,7 @@ pub fn extract_billboard_text(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            RenderEntity,
+            &RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
@@ -63,7 +63,7 @@ pub fn extract_billboard_text(
             // TODO: this will overwrite the render entity if we try to
             // TODO: add multiple handles in the same extraction!
             batch.push((
-                render_entity,
+                render_entity.id(),
                 (
                     uniform,
                     RenderBillboardMesh {
@@ -240,7 +240,7 @@ pub fn update_billboard_text_layout(
 
                 let mut mesh = Mesh::new(
                     PrimitiveTopology::TriangleList,
-                    RenderAssetUsages::default(),
+                    RenderAssetUsages::RENDER_WORLD,
                 );
 
                 mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,9 +1,6 @@
 use bevy::{
-    ecs::{
-        entity::Entity,
-        system::{Commands, Local, Query},
-    },
-    render::{view::ViewVisibility, Extract},
+    ecs::system::{Commands, Local, Query},
+    render::{sync_world::RenderEntity, view::ViewVisibility, Extract},
     transform::components::{GlobalTransform, Transform},
 };
 
@@ -11,7 +8,7 @@ use crate::{
     pipeline::{RenderBillboardImage, RenderBillboardMesh},
     text::RenderBillboard,
     utils::calculate_billboard_uniform,
-    BillboardDepth, BillboardLockAxis, BillboardMeshHandle, BillboardTextureHandle,
+    BillboardDepth, BillboardLockAxis, BillboardMesh, BillboardTexture,
 };
 
 pub fn extract_billboard_texture(
@@ -19,12 +16,12 @@ pub fn extract_billboard_texture(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            Entity,
+            RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
-            &BillboardMeshHandle,
-            &BillboardTextureHandle,
+            &BillboardMesh,
+            &BillboardTexture,
             &BillboardDepth,
             Option<&BillboardLockAxis>,
         )>,
@@ -33,7 +30,7 @@ pub fn extract_billboard_texture(
     let mut batch = Vec::with_capacity(*previous_len);
 
     for (
-        entity,
+        render_entity,
         visibility,
         global_transform,
         transform,
@@ -50,7 +47,7 @@ pub fn extract_billboard_texture(
         let uniform = calculate_billboard_uniform(global_transform, transform, lock_axis);
 
         batch.push((
-            entity,
+            render_entity,
             (
                 uniform,
                 RenderBillboardMesh {
@@ -68,5 +65,5 @@ pub fn extract_billboard_texture(
     }
 
     *previous_len = batch.len();
-    commands.insert_or_spawn_batch(batch);
+    commands.insert_batch(batch);
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -16,7 +16,7 @@ pub fn extract_billboard_texture(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            RenderEntity,
+            &RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
@@ -47,7 +47,7 @@ pub fn extract_billboard_texture(
         let uniform = calculate_billboard_uniform(global_transform, transform, lock_axis);
 
         batch.push((
-            render_entity,
+            render_entity.id(),
             (
                 uniform,
                 RenderBillboardMesh {

--- a/tests/text_usage.rs
+++ b/tests/text_usage.rs
@@ -6,21 +6,17 @@ use bevy_mod_billboard::prelude::*;
 fn text_binding_compatible_with_ui() {
     fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
+        let text_font = TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0);
 
-        let style = TextStyle {
-            font: fira_sans_regular_handle.clone(),
-            font_size: 60.0,
-            color: Color::WHITE,
-        };
+        commands.spawn(Camera3d::default());
 
-        commands.spawn(Camera3dBundle::default());
+        commands.spawn((
+            BillboardText::new("a"),
+            text_font.clone(),
+            TextColor::from(Color::WHITE),
+        ));
 
-        commands.spawn(BillboardTextBundle {
-            text: Text::from_section("a", style.clone()),
-            ..default()
-        });
-
-        commands.spawn(TextBundle::from_section("b", style));
+        commands.spawn((Text::new("b"), text_font, TextColor::from(Color::WHITE)));
     }
 
     App::new()


### PR DESCRIPTION
This patch is a migration to Bevy 0.16. 

It is based on #31 which migrated to Bevy 0.15 (not merged). There is only 1 additional commit. Comparatively, the migration from 0.15 to 0.16 was much easier. I also fixed a few clippy lints along the way.

Fixes #34. 