### PR TITLE
Migrate to Bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,8 @@ exclude = [ "images", "assets" ]
 smallvec = "1.11.0"
 bitflags = "2.3"
 
-# see bevy #16563
-bevy_internal = { version = "0.15", features = ["bevy_image"] }
-
 [dependencies.bevy]
-version = "0.15"
+version = "0.16"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -37,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.15"
+bevy = "0.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.11.0"
 bitflags = "2.3"
 
 [dependencies.bevy]
-version = "0.14"
+version = "0.15"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -34,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ exclude = [ "images", "assets" ]
 smallvec = "1.11.0"
 bitflags = "2.3"
 
+# see bevy #16563
+bevy_internal = { version = "0.15", features = ["bevy_image"] }
+
 [dependencies.bevy]
 version = "0.15"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.11.0"
 bitflags = "2.3"
 
 [dependencies.bevy]
-version = "0.16"
+version = "0.17"
 default-features = false
 features = [
     "bevy_core_pipeline",
@@ -34,4 +34,4 @@ features = [
 ]
 
 [dev-dependencies]
-bevy = "0.16"
+bevy = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ default-features = false
 features = [
     "bevy_core_pipeline",
     "bevy_render",
+    "bevy_sprite_render",
     "bevy_asset",
     "bevy_text",
     "bevy_sprite",
     "bevy_winit",
+    "bevy_log",
     "x11",
     "wayland",
 ]

--- a/README.md
+++ b/README.md
@@ -40,39 +40,31 @@ App::new()
 
 Text:
 ```rs
-commands.spawn(BillboardTextBundle {
-    transform: Transform::from_translation(Vec3::new(0., 2., 0.))
-        .with_scale(Vec3::splat(0.0085)),
-    text: Text::from_sections([
-        TextSection {
-            value: "IMPORTANT".to_string(),
-            style: TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::ORANGE,
-            }
-        },
-        TextSection {
-            value: " text".to_string(),
-            style: TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            }
-        }
-    ]).with_alignment(TextAlignment::CENTER),
-    ..default()
-});
+commands
+    .spawn((
+        BillboardText::default(),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_scale(Vec3::splat(0.0085)),
+    ))
+    .with_child((
+        TextSpan::new("IMPORTANT"),
+        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextColor::from(Color::Srgba(palettes::css::ORANGE)),
+    ))
+    .with_child((
+        TextSpan::new(" text"),
+        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextColor::from(Color::WHITE),
+    ));
 ```
 
 Texture:
 ```rs
-commands.spawn(BillboardTextureBundle {
-    transform: Transform::from_translation(Vec3::new(0., 5., 0.)),
-    texture: BillboardTextureHandle(handle.clone()),
-    mesh: BillboardMeshHandle(meshes.add(Quad::new(Vec2::new(4.0, 4.0)).into()).into()),
-    ..default()
-});
+commands.spawn((
+    BillboardTexture(image_handle.clone()),
+    BillboardMesh(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
+    Transform::from_xyz(0.0, 5.0, 0.0),
+));
 ```
 
 Full examples at [examples](examples).

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ Text:
 commands
     .spawn((
         BillboardText::default(),
-        TextLayout::new_with_justify(JustifyText::Center),
+        TextLayout::new_with_justify(Justify::Center),
         Transform::from_scale(Vec3::splat(0.0085)),
     ))
     .with_child((
         TextSpan::new("IMPORTANT"),
-        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextFont::from(fira_sans_regular_handle.clone()).with_font_size(60.0),
         TextColor::from(Color::Srgba(palettes::css::ORANGE)),
     ))
     .with_child((
         TextSpan::new(" text"),
-        TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+        TextFont::from(fira_sans_regular_handle.clone()).with_font_size(60.0),
         TextColor::from(Color::WHITE),
     ));
 ```

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -61,7 +61,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
-use bevy_mod_billboard::BillboardDepth;
 
 fn main() {
     App::new()
@@ -15,41 +14,31 @@ fn main() {
 const TEXT_SCALE: Vec3 = Vec3::splat(0.0085);
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
+    let text_font =
+        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
 
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_translation(Vec3::new(0., 0.5, 0.)).with_scale(TEXT_SCALE),
-        text: Text::from_section(
-            "depth enabled",
-            TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            },
-        )
-        .with_justify(JustifyText::Center),
-        ..default()
-    });
+    commands.spawn((
+        BillboardText::new("depth enabled"),
+        text_font.clone(),
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_xyz(0.0, 0.5, 0.0).with_scale(TEXT_SCALE),
+    ));
 
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_translation(Vec3::new(0., -0.5, 0.)).with_scale(TEXT_SCALE),
-        text: Text::from_section(
-            "depth disabled",
-            TextStyle {
-                font_size: 60.0,
-                font: fira_sans_regular_handle.clone(),
-                color: Color::WHITE,
-            },
-        )
-        .with_justify(JustifyText::Center),
-        billboard_depth: BillboardDepth(false),
-        ..default()
-    });
+    commands.spawn((
+        BillboardText::new("depth disabled"),
+        BillboardDepth(false),
+        text_font.clone(),
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Transform::from_xyz(0.0, -0.5, 0.0).with_scale(TEXT_SCALE),
+    ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -57,26 +46,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::BEIGE)),
-        transform: Transform::from_translation(Vec3::new(1., 0., 0.)),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::BEIGE))),
+        Transform::from_xyz(1., 0., 0.),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -14,14 +14,13 @@ fn main() {
 const TEXT_SCALE: Vec3 = Vec3::splat(0.0085);
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let text_font =
-        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
+    let text_font = TextFont::from(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
 
     commands.spawn((
         BillboardText::new("depth enabled"),
         text_font.clone(),
         TextColor(Color::WHITE),
-        TextLayout::new_with_justify(JustifyText::Center),
+        TextLayout::new_with_justify(Justify::Center),
         Transform::from_xyz(0.0, 0.5, 0.0).with_scale(TEXT_SCALE),
     ));
 
@@ -30,7 +29,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
         BillboardDepth(false),
         text_font.clone(),
         TextColor(Color::WHITE),
-        TextLayout::new_with_justify(JustifyText::Center),
+        TextLayout::new_with_justify(Justify::Center),
         Transform::from_xyz(0.0, -0.5, 0.0).with_scale(TEXT_SCALE),
     ));
 }

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -33,7 +33,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -56,7 +56,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -1,7 +1,6 @@
 use bevy::color::palettes;
 use bevy::prelude::*;
 use bevy_mod_billboard::prelude::*;
-use bevy_mod_billboard::BillboardLockAxis;
 
 fn main() {
     App::new()
@@ -13,42 +12,28 @@ fn main() {
 }
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
-    commands.spawn((
-        BillboardTextBundle {
-            transform: Transform::from_scale(Vec3::splat(0.0085))
-                .looking_at(Vec3::splat(5.0), Vec3::Y),
-            text: Text::from_sections([
-                TextSection {
-                    value: "LOCKED".to_string(),
-                    style: TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::Srgba(palettes::css::ORANGE),
-                    },
-                },
-                TextSection {
-                    value: " text".to_string(),
-                    style: TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::WHITE,
-                    },
-                },
-            ])
-            .with_justify(JustifyText::Center),
-            ..default()
-        },
-        BillboardLockAxis {
-            rotation: true,
-            ..default()
-        },
-    ));
+    let text_font =
+        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
+
+    commands
+        .spawn((
+            BillboardText::default(),
+            TextLayout::new_with_justify(JustifyText::Center),
+            Transform::from_scale(Vec3::splat(0.0085)).looking_at(Vec3::splat(5.0), Vec3::Y),
+            BillboardLockAxis::from_lock_rotation(true),
+        ))
+        .with_child((
+            TextSpan::new("LOCKED"),
+            text_font.clone(),
+            TextColor(Color::Srgba(palettes::css::ORANGE)),
+        ))
+        .with_child((TextSpan::new(" text"), text_font, TextColor(Color::WHITE)));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -56,26 +41,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_rotation.rs
+++ b/examples/lock_rotation.rs
@@ -12,13 +12,12 @@ fn main() {
 }
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let text_font =
-        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
+    let text_font = TextFont::from(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
 
     commands
         .spawn((
             BillboardText::default(),
-            TextLayout::new_with_justify(JustifyText::Center),
+            TextLayout::new_with_justify(Justify::Center),
             Transform::from_scale(Vec3::splat(0.0085)).looking_at(Vec3::splat(5.0), Vec3::Y),
             BillboardLockAxis::from_lock_rotation(true),
         ))

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -35,7 +35,7 @@ fn setup_billboard(
 // Important bits are above, the code below is for camera, reference plane and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -58,7 +58,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/lock_y.rs
+++ b/examples/lock_y.rs
@@ -28,7 +28,7 @@ fn setup_billboard(
     commands.spawn((
         BillboardTexture(image_handle),
         BillboardMesh(meshes.add(Rectangle::new(2.0, 4.0))),
-        Transform::from_xyz(2.0, 2.0, 0.0),
+        Transform::from_xyz(-2.0, 2.0, 0.0),
     ));
 }
 

--- a/examples/stress_test.rs
+++ b/examples/stress_test.rs
@@ -41,8 +41,7 @@ struct Settings {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut meshes: ResMut<Assets<Mesh>>) {
     let billboard_texture = BillboardTexture(asset_server.load("rust-logo-256x256.png"));
     let billboard_mesh = BillboardMesh(meshes.add(Rectangle::from_size(Vec2::splat(1.0))));
-    let text_font =
-        TextFont::from_font(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
+    let text_font = TextFont::from(asset_server.load("FiraSans-Regular.ttf")).with_font_size(60.0);
 
     commands.spawn((
         Camera3d::default(),

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -17,17 +17,17 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn((
             BillboardText::default(),
-            TextLayout::new_with_justify(JustifyText::Left),
+            TextLayout::new_with_justify(Justify::Left),
             Transform::from_scale(Vec3::splat(0.0085)),
         ))
         .with_child((
             TextSpan::new("IMPORTANT"),
-            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextFont::from(fira_sans_regular_handle.clone()).with_font_size(60.0),
             TextColor::from(Color::Srgba(palettes::css::ORANGE)),
         ))
         .with_child((
             TextSpan::new(" text"),
-            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextFont::from(fira_sans_regular_handle.clone()).with_font_size(60.0),
             TextColor::from(Color::WHITE),
         ));
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -35,7 +35,7 @@ fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -58,7 +58,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/text.rs
+++ b/examples/text.rs
@@ -13,34 +13,29 @@ fn main() {
 
 fn setup_billboard(mut commands: Commands, asset_server: Res<AssetServer>) {
     let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
-    commands.spawn(BillboardTextBundle {
-        transform: Transform::from_scale(Vec3::splat(0.0085)),
-        text: Text::from_sections([
-            TextSection {
-                value: "IMPORTANT".to_string(),
-                style: TextStyle {
-                    font_size: 60.0,
-                    font: fira_sans_regular_handle.clone(),
-                    color: Color::Srgba(palettes::css::ORANGE),
-                },
-            },
-            TextSection {
-                value: " text".to_string(),
-                style: TextStyle {
-                    font_size: 60.0,
-                    font: fira_sans_regular_handle.clone(),
-                    color: Color::WHITE,
-                },
-            },
-        ])
-        .with_justify(JustifyText::Center),
-        ..default()
-    });
+
+    commands
+        .spawn((
+            BillboardText::default(),
+            TextLayout::new_with_justify(JustifyText::Left),
+            Transform::from_scale(Vec3::splat(0.0085)),
+        ))
+        .with_child((
+            TextSpan::new("IMPORTANT"),
+            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextColor::from(Color::Srgba(palettes::css::ORANGE)),
+        ))
+        .with_child((
+            TextSpan::new(" text"),
+            TextFont::from_font(fira_sans_regular_handle.clone()).with_font_size(60.0),
+            TextColor::from(Color::WHITE),
+        ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -48,26 +43,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -26,7 +26,7 @@ fn setup_billboard(
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
-#[require(Transform)]
+#[require(Transform, Visibility)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -49,7 +49,7 @@ fn setup_scene(
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
-    let mut camera = camera.single_mut();
+    let mut camera = camera.single_mut().unwrap();
 
     camera.rotate_y(time.delta_secs());
 }

--- a/examples/texture.rs
+++ b/examples/texture.rs
@@ -17,16 +17,16 @@ fn setup_billboard(
     mut meshes: ResMut<Assets<Mesh>>,
 ) {
     let image_handle = asset_server.load("rust-logo-256x256.png");
-    commands.spawn(BillboardTextureBundle {
-        texture: BillboardTextureHandle(image_handle),
-        mesh: BillboardMeshHandle(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
-        ..default()
-    });
+    commands.spawn((
+        BillboardTexture(image_handle.clone()),
+        BillboardMesh(meshes.add(Rectangle::from_size(Vec2::splat(2.0)))),
+    ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 #[derive(Component)]
+#[require(Transform)]
 pub struct CameraHolder;
 
 fn setup_scene(
@@ -34,26 +34,22 @@ fn setup_scene(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands
-        .spawn((CameraHolder, Transform::IDENTITY, GlobalTransform::IDENTITY))
-        .with_children(|parent| {
-            parent.spawn(Camera3dBundle {
-                transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-                    .looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            });
-        });
-
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Cuboid::default()),
-        material: materials.add(Color::Srgba(palettes::css::GRAY)),
-        transform: Transform::from_translation(Vec3::NEG_Y * 2.),
-        ..default()
+    commands.spawn(CameraHolder).with_children(|parent| {
+        parent.spawn((
+            Camera3d::default(),
+            Transform::from_xyz(5., 0., 0.).looking_at(Vec3::ZERO, Vec3::Y),
+        ));
     });
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::default())),
+        MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+        Transform::from_translation(Vec3::NEG_Y * 2.),
+    ));
 }
 
 fn rotate_camera(mut camera: Query<&mut Transform, With<CameraHolder>>, time: Res<Time>) {
     let mut camera = camera.single_mut();
 
-    camera.rotate_y(time.delta_seconds());
+    camera.rotate_y(time.delta_secs());
 }

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -53,7 +53,7 @@ fn move_cube(
     mut direction: Local<bool>,
     time: Res<Time>,
 ) {
-    let mut parent_cube = parent_cube.single_mut();
+    let mut parent_cube = parent_cube.single_mut().unwrap();
 
     let direction_vec = if *direction { Vec3::Z } else { Vec3::NEG_Z };
 
@@ -62,6 +62,6 @@ fn move_cube(
 
     if *accumulated >= 2.0 {
         *direction = !*direction;
-        *accumulated = *accumulated - 2.0
+        *accumulated -= 2.0
     }
 }

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -31,10 +31,10 @@ fn setup_billboard(
         ))
         .with_child((
             BillboardText::new("parented text"),
-            TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0),
+            TextFont::from(fira_sans_regular_handle).with_font_size(60.0),
             TextColor(Color::WHITE),
             Transform::from_xyz(0.0, 1.0, 0.0).with_scale(Vec3::splat(0.0085)),
-            TextLayout::new_with_justify(JustifyText::Center),
+            TextLayout::new_with_justify(Justify::Center),
         ));
 }
 

--- a/examples/transform_propagation.rs
+++ b/examples/transform_propagation.rs
@@ -24,40 +24,27 @@ fn setup_billboard(
 
     commands
         .spawn((
-            PbrBundle {
-                mesh: meshes.add(Cuboid::default()),
-                material: materials.add(Color::Srgba(palettes::css::GRAY)),
-                transform: Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
-                ..default()
-            },
             ParentCube,
+            Mesh3d(meshes.add(Cuboid::default())),
+            MeshMaterial3d(materials.add(Color::Srgba(palettes::css::GRAY))),
+            Transform::from_translation(Vec3::new(0.0, -2.0, 1.0)),
         ))
-        .with_children(|parent| {
-            parent.spawn(BillboardTextBundle {
-                transform: Transform::from_translation(Vec3::new(0., 1.0, 0.))
-                    .with_scale(Vec3::splat(0.0085)),
-                text: Text::from_section(
-                    "parented text",
-                    TextStyle {
-                        font_size: 60.0,
-                        font: fira_sans_regular_handle.clone(),
-                        color: Color::WHITE,
-                    },
-                )
-                .with_justify(JustifyText::Center),
-                ..default()
-            });
-        });
+        .with_child((
+            BillboardText::new("parented text"),
+            TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0),
+            TextColor(Color::WHITE),
+            Transform::from_xyz(0.0, 1.0, 0.0).with_scale(Vec3::splat(0.0085)),
+            TextLayout::new_with_justify(JustifyText::Center),
+        ));
 }
 
 // Important bits are above, the code below is for camera, reference cube and rotation
 
 fn setup_scene(mut commands: Commands) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(Vec3::new(5., 0., 0.))
-            .looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3d::default(),
+        Transform::from_xyz(5.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 }
 
 fn move_cube(
@@ -70,8 +57,8 @@ fn move_cube(
 
     let direction_vec = if *direction { Vec3::Z } else { Vec3::NEG_Z };
 
-    parent_cube.translation += time.delta_seconds() * direction_vec;
-    *accumulated += time.delta_seconds();
+    parent_cube.translation += time.delta_secs() * direction_vec;
+    *accumulated += time.delta_secs();
 
     if *accumulated >= 2.0 {
         *direction = !*direction;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::type_complexity)]
+#![allow(clippy::too_many_arguments)]
+
 pub mod pipeline;
 pub mod plugin;
 pub mod text;
@@ -5,13 +8,15 @@ pub mod texture;
 mod utils;
 
 use crate::text::{BillboardTextBounds, BillboardTextHandles};
+use bevy::asset::weak_handle;
 use bevy::prelude::*;
 use bevy::render::extract_component::ExtractComponent;
+use bevy::render::view::{add_visibility_class, VisibilityClass};
 use bevy::sprite::Anchor;
 use bevy::text::{TextRoot, TextSpanAccess};
 
-pub(self) const BILLBOARD_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(12823766040132746076);
+const BILLBOARD_SHADER_HANDLE: Handle<Shader> =
+    weak_handle!("69c21ac3-19fa-4663-aef8-7b4e8f1a6e61");
 
 /// Marker component for a billboarded texture.
 ///
@@ -94,7 +99,8 @@ impl Default for BillboardDepth {
 }
 
 #[derive(Default, Clone, Copy, Component, ExtractComponent, Debug, Reflect)]
-#[require(BillboardDepth)]
+#[require(BillboardDepth, VisibilityClass)]
+#[component(on_add = add_visibility_class::<Billboard>)]
 pub struct Billboard;
 
 #[derive(Default, Clone, Copy, Component, Debug, Reflect)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ impl From<String> for BillboardText {
     }
 }
 
+#[derive(Clone, Component, Default)]
+#[component(storage = "SparseSet")]
+struct BillboardTextNeedsRerender;
+
 #[derive(Clone, Component, Reflect, Default)]
 #[reflect(Component)]
 pub struct BillboardMesh(pub Handle<Mesh>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,8 @@ pub struct BillboardTexture(pub Handle<Image>);
 ///
 /// # Warning
 ///
-/// This component is incompatible with [`Text`] and [`Text2d`]!
-/// Bevy will attempt to render the `Text` in the UI and `Text2D` as 2D
+/// This component is incompatible with Bevy's `Text` and `Text2d`!
+/// Bevy will attempt to render the `Text` in the UI and `Text2d` as 2D
 /// text, corrupting the internal `TextLayoutInfo` used by billboarding.
 ///
 /// If you are not using `TextSpan` children, set the `String` field of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,15 +8,11 @@ pub mod texture;
 mod utils;
 
 use crate::text::{BillboardTextBounds, BillboardTextHandles};
-use bevy::asset::weak_handle;
+use bevy::camera::visibility::{add_visibility_class, VisibilityClass};
 use bevy::prelude::*;
 use bevy::render::extract_component::ExtractComponent;
-use bevy::render::view::{add_visibility_class, VisibilityClass};
 use bevy::sprite::Anchor;
 use bevy::text::{TextRoot, TextSpanAccess};
-
-const BILLBOARD_SHADER_HANDLE: Handle<Shader> =
-    weak_handle!("69c21ac3-19fa-4663-aef8-7b4e8f1a6e61");
 
 /// Marker component for a billboarded texture.
 ///

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,23 +1,22 @@
 use crate::text::RenderBillboard;
-use crate::{Billboard, BILLBOARD_SHADER_HANDLE};
-use bevy::asset::AssetId;
+use crate::Billboard;
+use bevy::asset::{load_embedded_asset, AssetId, AssetServer, Handle};
 use bevy::core_pipeline::core_3d::Transparent3d;
 use bevy::ecs::query::ROQueryItem;
 use bevy::ecs::system::lifetimeless::{Read, SRes};
-use bevy::ecs::system::{SystemParamItem, SystemState};
+use bevy::ecs::system::SystemParamItem;
 use bevy::image::BevyDefault;
 use bevy::log::error;
 use bevy::math::Mat4;
+use bevy::mesh::{MeshVertexBufferLayoutRef, PrimitiveTopology};
 use bevy::platform::collections::HashMap;
 use bevy::prelude::{
-    default, AssetEvent, Commands, Component, Entity, FromWorld, Image, Mesh, Msaa, Query, Res,
-    ResMut, Resource, With, World,
+    default, AssetEvent, Commands, Component, Entity, Image, Mesh, Msaa, Query, Res, ResMut,
+    Resource, With,
 };
 use bevy::render::extract_component::{ComponentUniforms, DynamicUniformIndex};
 use bevy::render::mesh::allocator::MeshAllocator;
-use bevy::render::mesh::{
-    MeshVertexBufferLayoutRef, PrimitiveTopology, RenderMesh, RenderMeshBufferInfo,
-};
+use bevy::render::mesh::{RenderMesh, RenderMeshBufferInfo};
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_phase::{
     DrawFunctions, PhaseItemExtraIndex, RenderCommand, RenderCommandResult, SetItemPipeline,
@@ -36,7 +35,8 @@ use bevy::render::texture::GpuImage;
 use bevy::render::view::{
     ExtractedView, RenderVisibleEntities, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
 };
-use bevy::sprite::SpriteAssetEvents;
+use bevy::shader::Shader;
+use bevy::sprite_render::SpriteAssetEvents;
 
 #[derive(Clone, Copy, ShaderType, Component)]
 pub struct BillboardUniform {
@@ -271,70 +271,73 @@ pub struct BillboardPipeline {
     view_layout: BindGroupLayout,
     billboard_layout: BindGroupLayout,
     texture_layout: BindGroupLayout,
+    shader: Handle<Shader>,
 }
 
-impl FromWorld for BillboardPipeline {
-    fn from_world(world: &mut World) -> Self {
-        let mut system_state: SystemState<(Res<RenderDevice>,)> = SystemState::new(world);
+pub(crate) fn init_billboard_pipeline(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    assets: Res<AssetServer>,
+) {
+    let view_layout = render_device.create_bind_group_layout(
+        "billboard_view_layout",
+        &[BindGroupLayoutEntry {
+            binding: 0,
+            visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Uniform,
+                has_dynamic_offset: true,
+                min_binding_size: Some(ViewUniform::min_size()),
+            },
+            count: None,
+        }],
+    );
 
-        let (render_device,) = system_state.get(world);
+    let billboard_layout = render_device.create_bind_group_layout(
+        "billboard_layout",
+        &[BindGroupLayoutEntry {
+            binding: 0,
+            visibility: ShaderStages::VERTEX,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Uniform,
+                has_dynamic_offset: true,
+                min_binding_size: Some(BillboardUniform::min_size()),
+            },
+            count: None,
+        }],
+    );
 
-        let view_layout = render_device.create_bind_group_layout(
-            "billboard_view_layout",
-            &[BindGroupLayoutEntry {
+    let texture_layout = render_device.create_bind_group_layout(
+        "billboard_texture_layout",
+        &[
+            BindGroupLayoutEntry {
                 binding: 0,
-                visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
-                ty: BindingType::Buffer {
-                    ty: BufferBindingType::Uniform,
-                    has_dynamic_offset: true,
-                    min_binding_size: Some(ViewUniform::min_size()),
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Texture {
+                    multisampled: false,
+                    sample_type: TextureSampleType::Float { filterable: true },
+                    view_dimension: TextureViewDimension::D2,
                 },
                 count: None,
-            }],
-        );
-
-        let billboard_layout = render_device.create_bind_group_layout(
-            "billboard_layout",
-            &[BindGroupLayoutEntry {
-                binding: 0,
-                visibility: ShaderStages::VERTEX,
-                ty: BindingType::Buffer {
-                    ty: BufferBindingType::Uniform,
-                    has_dynamic_offset: true,
-                    min_binding_size: Some(BillboardUniform::min_size()),
-                },
+            },
+            BindGroupLayoutEntry {
+                binding: 1,
+                visibility: ShaderStages::FRAGMENT,
+                ty: BindingType::Sampler(SamplerBindingType::Filtering),
                 count: None,
-            }],
-        );
+            },
+        ],
+    );
 
-        let texture_layout = render_device.create_bind_group_layout(
-            "billboard_texture_layout",
-            &[
-                BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Texture {
-                        multisampled: false,
-                        sample_type: TextureSampleType::Float { filterable: true },
-                        view_dimension: TextureViewDimension::D2,
-                    },
-                    count: None,
-                },
-                BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: ShaderStages::FRAGMENT,
-                    ty: BindingType::Sampler(SamplerBindingType::Filtering),
-                    count: None,
-                },
-            ],
-        );
+    let shader = load_embedded_asset!(assets.as_ref(), "shader/billboard.wgsl");
 
-        Self {
-            view_layout,
-            billboard_layout,
-            texture_layout,
-        }
-    }
+    let pipeline = BillboardPipeline {
+        view_layout,
+        billboard_layout,
+        texture_layout,
+        shader,
+    };
+    commands.insert_resource(pipeline);
 }
 
 impl SpecializedMeshPipeline for BillboardPipeline {
@@ -385,14 +388,14 @@ impl SpecializedMeshPipeline for BillboardPipeline {
                 self.texture_layout.clone(),
             ],
             vertex: VertexState {
-                shader: BILLBOARD_SHADER_HANDLE,
-                entry_point: "vertex".into(),
+                shader: self.shader.clone(),
+                entry_point: None,
                 buffers: vec![vertex_buffer_layout],
                 shader_defs: shader_defs.clone(),
             },
             fragment: Some(FragmentState {
-                shader: BILLBOARD_SHADER_HANDLE,
-                entry_point: "fragment".into(),
+                shader: self.shader.clone(),
+                entry_point: None,
                 shader_defs,
                 targets: vec![Some(ColorTargetState {
                     format: if key.contains(BillboardPipelineKey::HDR) {
@@ -450,8 +453,8 @@ impl<const I: usize> RenderCommand<Transparent3d> for SetBillboardViewBindGroup<
 
     fn render<'w>(
         _item: &Transparent3d,
-        (view_uniform, billboard_mesh_bind_group): ROQueryItem<'w, Self::ViewQuery>,
-        _item_query: Option<ROQueryItem<'w, Self::ItemQuery>>,
+        (view_uniform, billboard_mesh_bind_group): ROQueryItem<'w, '_, Self::ViewQuery>,
+        _item_query: Option<ROQueryItem<'w, '_, Self::ItemQuery>>,
         _param: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -469,8 +472,8 @@ impl<const I: usize> RenderCommand<Transparent3d> for SetBillboardBindGroup<I> {
 
     fn render<'w>(
         _item: &Transparent3d,
-        _view: ROQueryItem<'w, Self::ViewQuery>,
-        billboard_index: Option<ROQueryItem<'w, Self::ItemQuery>>,
+        _view: ROQueryItem<'w, '_, Self::ViewQuery>,
+        billboard_index: Option<ROQueryItem<'w, '_, Self::ItemQuery>>,
         billboard_bind_group: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -494,8 +497,8 @@ impl<const I: usize> RenderCommand<Transparent3d> for SetBillboardTextureBindGro
 
     fn render<'w>(
         _item: &Transparent3d,
-        _view: ROQueryItem<'w, Self::ViewQuery>,
-        billboard_texture: Option<ROQueryItem<'w, Self::ItemQuery>>,
+        _view: ROQueryItem<'w, '_, Self::ViewQuery>,
+        billboard_texture: Option<ROQueryItem<'w, '_, Self::ItemQuery>>,
         images: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -520,8 +523,8 @@ impl RenderCommand<Transparent3d> for DrawBillboardMesh {
 
     fn render<'w>(
         _item: &Transparent3d,
-        _view: ROQueryItem<'w, Self::ViewQuery>,
-        mesh: Option<ROQueryItem<'w, Self::ItemQuery>>,
+        _view: ROQueryItem<'w, '_, Self::ViewQuery>,
+        mesh: Option<ROQueryItem<'w, '_, Self::ItemQuery>>,
         (meshes, mesh_allocator): SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -13,8 +13,6 @@ use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
-use bevy::render::view::check_visibility;
-use bevy::render::view::VisibilitySystems::CheckVisibility;
 use bevy::render::{RenderApp, RenderSet};
 use bevy::text::detect_text_needs_rerender;
 use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
@@ -40,16 +38,13 @@ impl Plugin for BillboardPlugin {
                 PostUpdate,
                 (
                     (
-                        (
-                            detect_text_needs_rerender::<BillboardText>,
-                            detect_billboard_text_color_change,
-                        ),
-                        update_billboard_text_layout,
-                    )
-                        .chain()
-                        .ambiguous_with(CameraUpdateSystem),
-                    check_visibility::<With<Billboard>>.in_set(CheckVisibility),
-                ),
+                        detect_text_needs_rerender::<BillboardText>,
+                        detect_billboard_text_color_change,
+                    ),
+                    update_billboard_text_layout,
+                )
+                    .chain()
+                    .ambiguous_with(CameraUpdateSystem),
             );
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -4,9 +4,7 @@ use crate::pipeline::{
 };
 use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
 use crate::texture::extract_billboard_texture;
-use crate::{
-    Billboard, BillboardMesh, BillboardTextBounds, BillboardTexture, BILLBOARD_SHADER_HANDLE,
-};
+use crate::{prelude::*, Billboard, BILLBOARD_SHADER_HANDLE};
 use bevy::prelude::*;
 use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
@@ -15,6 +13,7 @@ use bevy::render::render_resource::SpecializedMeshPipelines;
 use bevy::render::view::check_visibility;
 use bevy::render::view::VisibilitySystems::CheckVisibility;
 use bevy::render::{RenderApp, RenderSet};
+use bevy::text::detect_text_needs_rerender;
 use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
 
 pub struct BillboardPlugin;
@@ -37,7 +36,12 @@ impl Plugin for BillboardPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    update_billboard_text_layout.ambiguous_with(CameraUpdateSystem),
+                    (
+                        detect_text_needs_rerender::<BillboardText>,
+                        update_billboard_text_layout,
+                    )
+                        .chain()
+                        .ambiguous_with(CameraUpdateSystem),
                     check_visibility::<With<Billboard>>.in_set(CheckVisibility),
                 ),
             );

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,10 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
+use crate::text::{
+    detect_billboard_text_color_change, extract_billboard_text, update_billboard_text_layout,
+    BillboardTextHandles,
+};
 use crate::texture::extract_billboard_texture;
 use crate::{prelude::*, Billboard, BILLBOARD_SHADER_HANDLE};
 use bevy::prelude::*;
@@ -37,7 +40,10 @@ impl Plugin for BillboardPlugin {
                 PostUpdate,
                 (
                     (
-                        detect_text_needs_rerender::<BillboardText>,
+                        (
+                            detect_text_needs_rerender::<BillboardText>,
+                            detect_billboard_text_color_change,
+                        ),
                         update_billboard_text_layout,
                     )
                         .chain()

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,15 +2,14 @@ use crate::pipeline::{
     prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
     BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
 };
-use crate::text::{extract_billboard_text, update_billboard_text_layout};
+use crate::text::{extract_billboard_text, update_billboard_text_layout, BillboardTextHandles};
 use crate::texture::extract_billboard_texture;
 use crate::{
-    Billboard, BillboardMeshHandle, BillboardTextBounds, BillboardTextureHandle,
-    BILLBOARD_SHADER_HANDLE,
+    Billboard, BillboardMesh, BillboardTextBounds, BillboardTexture, BILLBOARD_SHADER_HANDLE,
 };
 use bevy::prelude::*;
 use bevy::render::camera::CameraUpdateSystem;
-use bevy::render::extract_component::UniformComponentPlugin;
+use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
 use bevy::render::view::check_visibility;
@@ -30,9 +29,11 @@ impl Plugin for BillboardPlugin {
         );
 
         app.add_plugins(UniformComponentPlugin::<BillboardUniform>::default())
-            .register_type::<BillboardMeshHandle>()
-            .register_type::<BillboardTextureHandle>()
+            .add_plugins(ExtractComponentPlugin::<Billboard>::default())
+            .register_type::<BillboardMesh>()
+            .register_type::<BillboardTexture>()
             .register_type::<BillboardTextBounds>()
+            .register_type::<BillboardTextHandles>()
             .add_systems(
                 PostUpdate,
                 (

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,32 +1,29 @@
 use crate::pipeline::{
-    prepare_billboard_bind_group, prepare_billboard_view_bind_groups, queue_billboard_texture,
-    BillboardImageBindGroups, BillboardPipeline, BillboardUniform, DrawBillboard,
+    init_billboard_pipeline, prepare_billboard_bind_group, prepare_billboard_view_bind_groups,
+    queue_billboard_texture, BillboardImageBindGroups, BillboardPipeline, BillboardUniform,
+    DrawBillboard,
 };
 use crate::text::{
     detect_billboard_text_color_change, extract_billboard_text, update_billboard_text_layout,
     BillboardTextHandles,
 };
 use crate::texture::extract_billboard_texture;
-use crate::{prelude::*, Billboard, BILLBOARD_SHADER_HANDLE};
+use crate::{prelude::*, Billboard};
+use bevy::camera::CameraUpdateSystems;
 use bevy::prelude::*;
-use bevy::render::camera::CameraUpdateSystem;
 use bevy::render::extract_component::{ExtractComponentPlugin, UniformComponentPlugin};
 use bevy::render::render_phase::AddRenderCommand;
 use bevy::render::render_resource::SpecializedMeshPipelines;
-use bevy::render::{RenderApp, RenderSet};
+use bevy::render::{RenderApp, RenderStartup, RenderSystems};
+use bevy::shader::load_shader_library;
 use bevy::text::detect_text_needs_rerender;
-use bevy::{asset::load_internal_asset, core_pipeline::core_3d::Transparent3d, render::Render};
+use bevy::{core_pipeline::core_3d::Transparent3d, render::Render};
 
 pub struct BillboardPlugin;
 
 impl Plugin for BillboardPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            BILLBOARD_SHADER_HANDLE,
-            "shader/billboard.wgsl",
-            Shader::from_wgsl
-        );
+        load_shader_library!(app, "shader/billboard.wgsl");
 
         app.add_plugins(UniformComponentPlugin::<BillboardUniform>::default())
             .add_plugins(ExtractComponentPlugin::<Billboard>::default())
@@ -44,28 +41,26 @@ impl Plugin for BillboardPlugin {
                     update_billboard_text_layout,
                 )
                     .chain()
-                    .ambiguous_with(CameraUpdateSystem),
+                    .ambiguous_with(CameraUpdateSystems),
             );
-    }
 
-    fn finish(&self, app: &mut App) {
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawBillboard>()
-            .init_resource::<BillboardPipeline>()
             .init_resource::<SpecializedMeshPipelines<BillboardPipeline>>()
             .init_resource::<BillboardImageBindGroups>()
+            .add_systems(RenderStartup, init_billboard_pipeline)
             .add_systems(
                 ExtractSchedule,
                 (extract_billboard_text, extract_billboard_texture),
             )
-            .add_systems(Render, queue_billboard_texture.in_set(RenderSet::Queue))
+            .add_systems(Render, queue_billboard_texture.in_set(RenderSystems::Queue))
             .add_systems(
                 Render,
-                prepare_billboard_bind_group.in_set(RenderSet::PrepareBindGroups),
+                prepare_billboard_bind_group.in_set(RenderSystems::PrepareBindGroups),
             )
             .add_systems(
                 Render,
-                prepare_billboard_view_bind_groups.in_set(RenderSet::PrepareBindGroups),
+                prepare_billboard_view_bind_groups.in_set(RenderSystems::PrepareBindGroups),
             );
     }
 }

--- a/src/shader/billboard.wgsl
+++ b/src/shader/billboard.wgsl
@@ -45,11 +45,11 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     let vertex_position = vec4<f32>(-vertex.position.x, vertex.position.y, vertex.position.z, 1.0);
     let position = view.view_proj * billboard.model * vertex_position;
 #else
-    let camera_right = normalize(vec3<f32>(view.view_proj.x.x, view.view_proj.y.x, view.view_proj.z.x));
+    let camera_right = normalize(vec3<f32>(view.view_proj[0][0], view.view_proj[1][0], view.view_proj[2][0]));
 #ifdef LOCK_Y
     let camera_up = vec3<f32>(0.0, 1.0, 0.0);
 #else
-    let camera_up = normalize(vec3<f32>(view.view_proj.x.y, view.view_proj.y.y, view.view_proj.z.y));
+    let camera_up = normalize(vec3<f32>(view.view_proj[0][1], view.view_proj[1][1], view.view_proj[2][1]));
 #endif
 
     let world_space = camera_right * vertex.position.x + camera_up * vertex.position.y;

--- a/src/text.rs
+++ b/src/text.rs
@@ -38,7 +38,7 @@ pub fn extract_billboard_text(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            RenderEntity,
+            &RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
@@ -63,7 +63,7 @@ pub fn extract_billboard_text(
             // TODO: this will overwrite the render entity if we try to
             // TODO: add multiple handles in the same extraction!
             batch.push((
-                render_entity,
+                render_entity.id(),
                 (
                     uniform,
                     RenderBillboardMesh {
@@ -240,7 +240,7 @@ pub fn update_billboard_text_layout(
 
                 let mut mesh = Mesh::new(
                     PrimitiveTopology::TriangleList,
-                    RenderAssetUsages::default(),
+                    RenderAssetUsages::RENDER_WORLD,
                 );
 
                 mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,17 +1,17 @@
 use crate::pipeline::{RenderBillboardImage, RenderBillboardMesh};
 use crate::utils::calculate_billboard_uniform;
 use crate::{BillboardDepth, BillboardLockAxis, BillboardText, BillboardTextNeedsRerender};
+use bevy::asset::RenderAssetUsages;
 use bevy::color::palettes;
+use bevy::mesh::{Indices, PrimitiveTopology};
 use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::*;
-use bevy::render::mesh::{Indices, PrimitiveTopology};
-use bevy::render::render_asset::RenderAssetUsages;
 use bevy::render::sync_world::RenderEntity;
 use bevy::render::Extract;
 use bevy::sprite::Anchor;
 use bevy::text::{
     ComputedTextBlock, CosmicFontSystem, FontAtlasSets, PositionedGlyph, SwashCache, TextBounds,
-    TextLayoutInfo, TextPipeline, TextReader, YAxisOrientation,
+    TextLayoutInfo, TextPipeline, TextReader,
 };
 use smallvec::SmallVec;
 
@@ -30,7 +30,7 @@ pub struct BillboardTextHandles(pub SmallVec<[BillboardTextHandleGroup; 1]>);
 #[derive(Clone, Debug, Default, Reflect)]
 pub struct BillboardTextHandleGroup {
     mesh: Handle<Mesh>,
-    image: Handle<Image>,
+    image: AssetId<Image>,
 }
 
 pub fn extract_billboard_text(
@@ -70,7 +70,7 @@ pub fn extract_billboard_text(
                         id: handle_group.mesh.id(),
                     },
                     RenderBillboardImage {
-                        id: handle_group.image.id(),
+                        id: handle_group.image,
                     },
                     RenderBillboard {
                         depth,
@@ -147,7 +147,6 @@ pub(crate) fn update_billboard_text_layout(
                 &mut font_atlas_set_storage,
                 &mut texture_atlases,
                 &mut images,
-                YAxisOrientation::BottomToTop,
                 computed.as_mut(),
                 &mut font_system,
                 &mut swash_cache,
@@ -180,15 +179,15 @@ pub(crate) fn update_billboard_text_layout(
                 // TODO: Maybe with clever caching, could be possible to get rid of or_insert_with,
                 // TODO: though I don't know how much of a gain it would be. Just keeping this as a note.
                 let entry = textures
-                    .entry(glyph.atlas_info.texture.clone_weak())
+                    .entry(glyph.atlas_info.texture.clone())
                     .or_insert_with(|| {
                         (
                             Vec::with_capacity(length),
                             (
                                 texture_atlases
-                                    .get(&glyph.atlas_info.texture_atlas)
+                                    .get(glyph.atlas_info.texture_atlas)
                                     .expect("Atlas should exist"),
-                                glyph.atlas_info.texture.clone_weak(),
+                                glyph.atlas_info.texture.clone(),
                             ),
                         )
                     });
@@ -216,7 +215,7 @@ pub(crate) fn update_billboard_text_layout(
                 } in glyphs
                 {
                     let index = positions.len() as u32;
-                    let position = position + alignment_translation;
+                    let position = (position + alignment_translation) * Vec2::new(1.0, -1.0);
 
                     let half_size = size / 2.0;
                     let top_left = position - half_size;

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,6 +1,7 @@
 use bevy::{
+    camera::visibility::ViewVisibility,
     ecs::system::{Commands, Local, Query},
-    render::{sync_world::RenderEntity, view::ViewVisibility, Extract},
+    render::{sync_world::RenderEntity, Extract},
     transform::components::{GlobalTransform, Transform},
 };
 

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -1,9 +1,6 @@
 use bevy::{
-    ecs::{
-        entity::Entity,
-        system::{Commands, Local, Query},
-    },
-    render::{view::ViewVisibility, Extract},
+    ecs::system::{Commands, Local, Query},
+    render::{sync_world::RenderEntity, view::ViewVisibility, Extract},
     transform::components::{GlobalTransform, Transform},
 };
 
@@ -11,7 +8,7 @@ use crate::{
     pipeline::{RenderBillboardImage, RenderBillboardMesh},
     text::RenderBillboard,
     utils::calculate_billboard_uniform,
-    BillboardDepth, BillboardLockAxis, BillboardMeshHandle, BillboardTextureHandle,
+    BillboardDepth, BillboardLockAxis, BillboardMesh, BillboardTexture,
 };
 
 pub fn extract_billboard_texture(
@@ -19,12 +16,12 @@ pub fn extract_billboard_texture(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            Entity,
+            RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
-            &BillboardMeshHandle,
-            &BillboardTextureHandle,
+            &BillboardMesh,
+            &BillboardTexture,
             &BillboardDepth,
             Option<&BillboardLockAxis>,
         )>,
@@ -33,7 +30,7 @@ pub fn extract_billboard_texture(
     let mut batch = Vec::with_capacity(*previous_len);
 
     for (
-        entity,
+        render_entity,
         visibility,
         global_transform,
         transform,
@@ -50,7 +47,7 @@ pub fn extract_billboard_texture(
         let uniform = calculate_billboard_uniform(global_transform, transform, lock_axis);
 
         batch.push((
-            entity,
+            render_entity,
             (
                 uniform,
                 RenderBillboardMesh {
@@ -68,5 +65,5 @@ pub fn extract_billboard_texture(
     }
 
     *previous_len = batch.len();
-    commands.insert_or_spawn_batch(batch);
+    commands.insert_batch(batch);
 }

--- a/src/texture.rs
+++ b/src/texture.rs
@@ -16,7 +16,7 @@ pub fn extract_billboard_texture(
     mut previous_len: Local<usize>,
     billboard_text_query: Extract<
         Query<(
-            RenderEntity,
+            &RenderEntity,
             &ViewVisibility,
             &GlobalTransform,
             &Transform,
@@ -47,7 +47,7 @@ pub fn extract_billboard_texture(
         let uniform = calculate_billboard_uniform(global_transform, transform, lock_axis);
 
         batch.push((
-            render_entity,
+            render_entity.id(),
             (
                 uniform,
                 RenderBillboardMesh {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ pub fn compute_matrix_without_rotation(
     global_transform: &GlobalTransform,
     transform: &Transform,
 ) -> Mat4 {
-    let global_matrix = global_transform.compute_matrix();
+    let global_matrix = global_transform.to_matrix();
     Mat4::from_cols(
         Mat4::IDENTITY.x_axis * transform.scale.x,
         Mat4::IDENTITY.y_axis * transform.scale.y,
@@ -25,7 +25,7 @@ pub fn calculate_billboard_uniform(
     lock_axis: Option<&BillboardLockAxis>,
 ) -> BillboardUniform {
     let transform = if lock_axis.is_some() {
-        global_transform.compute_matrix()
+        global_transform.to_matrix()
     } else {
         compute_matrix_without_rotation(global_transform, transform)
     };

--- a/tests/text_usage.rs
+++ b/tests/text_usage.rs
@@ -6,7 +6,7 @@ use bevy_mod_billboard::prelude::*;
 fn text_binding_compatible_with_ui() {
     fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
-        let text_font = TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0);
+        let text_font = TextFont::from(fira_sans_regular_handle).with_font_size(60.0);
 
         commands.spawn(Camera3d::default());
 

--- a/tests/text_usage.rs
+++ b/tests/text_usage.rs
@@ -6,21 +6,17 @@ use bevy_mod_billboard::prelude::*;
 fn text_binding_compatible_with_ui() {
     fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         let fira_sans_regular_handle = asset_server.load("FiraSans-Regular.ttf");
+        let text_font = TextFont::from_font(fira_sans_regular_handle).with_font_size(60.0);
 
-        let style = TextStyle {
-            font: fira_sans_regular_handle.clone(),
-            font_size: 60.0,
-            color: Color::WHITE,
-        };
+        commands.spawn(Camera3d::default());
 
-        commands.spawn(Camera3dBundle::default());
+        commands.spawn((
+            BillboardText::new("a"),
+            text_font.clone(),
+            TextColor::from(Color::WHITE),
+        ));
 
-        commands.spawn(BillboardTextBundle {
-            text: Text::from_section("a", style.clone()),
-            ..default()
-        });
-
-        commands.spawn(TextBundle::from_section("b", style));
+        commands.spawn((Text::new("b"), text_font, TextColor::from(Color::WHITE)));
     }
 
     App::new()


### PR DESCRIPTION
Update the library to support `bevy = "0.17`.

Not much changed:
- Switched embedded shader loading to `load_shader_library` since it seems to be the right way in bevy ?
- Moved pipeline initialization from `BillboardPlugin::finish` to a new `init_billboard_pipeline` system in `RenderStartup`.
- `YAxisOrientation` is removed, so the migration seems to be flipping glyph's *y* position.

*Note: it's possible to also migrate pipeline specialization to the new `Specializer<RenderPipeline>` + `Variants` workflow, but I'm not very well versed in this part of the rendering, luckily it's not breaking if not migrated.*

Standing on the shoulders of giants: https://github.com/kulkalkul/bevy_mod_billboard/pull/31 and https://github.com/kulkalkul/bevy_mod_billboard/pull/35.